### PR TITLE
Added new LLVM specific helper functions

### DIFF
--- a/common/llvm.saw
+++ b/common/llvm.saw
@@ -19,6 +19,15 @@ let points_to = crucible_points_to;
 let precond = crucible_precond;
 let from_cryptol = crucible_term;
 
+let global = crucible_global;
+let global_alloc = crucible_alloc_global;
+let global_init name = do {
+  global_alloc name;
+  points_to (global name)
+            (crucible_global_initializer name);
+};
+let element = crucible_elem;
+let equal = crucible_equal;
 let execute = crucible_execute_func;
 let postcond = crucible_postcond;
 let returns = crucible_return;
@@ -30,29 +39,60 @@ let llvm_verify module function_name overrides spec =
 // pointing to.
 let CONST  = {{ 0 : [2] }}; //Points to allocated space that is READ ONLY.
 let WRITE  = {{ 1 : [2] }}; //Points to allocated space that can be modified.
-let UNINIT = {{ 2 : [2] }}; //Pointer does not point to allocated space.
+let UNALLOC = {{ 2 : [2] }}; //Pointer does not point to allocated space.
 
-// Returns a pointer of the given type.
+/**
+ * Returns a pointer of the given type. The first argument is either
+ * CONST, WRITE, or UNALLOC. The second argument is the type of the
+ * value the pointer can point to.
+ *
+ * For example, the following creates a pointer to allocated space
+ * that is read only.
+ *
+ *   p <- pointer CONST (llvm_array 4 uint32_t);
+ *
+ * The following creates a pointer to allocated space that can be
+ * modified.
+ *
+ *   p <- pointer WRITE (llvm_array 4 uint32_t);
+ *
+ *
+ * The following creates a pointer that is either unallocated or
+ * NULL, i.e. that does not point to allocated space.
+ *
+ *   p <- pointer UNALLOC (llvm_array 4 uint32_t);
+ */ 
 let pointer (rw : Term) (type : LLVMType) =
-  if     (eval_bool {{ rw == 0 }}) then crucible_alloc_readonly type
-  else if(eval_bool {{ rw == 1 }}) then crucible_alloc type
-  else                                  crucible_fresh_pointer type;
+  if (eval_bool {{ rw == CONST }}) then crucible_alloc_readonly type
+  else if (eval_bool {{ rw == WRITE }}) then crucible_alloc type
+  else crucible_fresh_pointer type;
 
 //Symbolic value --- for use with the `variable` function.
-let FRESH   = { fresh={{ True }} : Term, t={{ error "NEW Term field was accessed" }} : Term};
+let FRESH = { fresh={{ True }} : Term, t={{ error "NEW Term field was accessed" }} : Term};
 //Concrete value --- for use with the `variable` function.
 let STALE (t : Term) = { fresh={{ False }} : Term, t=t : Term};
 
+//Empty variable --- called by the `variable` function.
 let variable_empty = do {
   return {{ False }};
 };
 
-// Returns a NULL pointer, the SetupValue, and a Term for either a new
-// symbolic variable or a term passed in.
-// Should be called like:
-//   variable "name" (llvm_int 32) SYM;
-// or
-//   variable "name" (llvm_int 32) (CON {{ 10 : [32] }});
+/**
+ * Returns a NULL pointer, SetupValue, and Term for either a new
+ * symbolic variable or a term passed in. The first argument is the
+ * type of the variable to be created. The second argument is a name
+ * that is printed during debugging or counterexamples. The third
+ * argument is either FRESH or STALE.
+ *
+ * For example, the following creates a 32-bit variable that can take
+ * on any 32-bit value.
+ *
+ *   v <- variable (llvm_int 32) "name" FRESH
+ *
+ * The following creates a 32-bit variable assigned to 10.
+ *
+ *   v <- variable (llvm_int 32) "name" (STALE {{ 10 : [32] }})
+ */
 let variable (type : LLVMType) (name : String) (v : { fresh : Term, t : Term}) = do {
   cfv <- if (eval_bool v.fresh) then (crucible_fresh_var name type) else variable_empty;
   let t = if (eval_bool v.fresh) then cfv else v.t;
@@ -60,13 +100,29 @@ let variable (type : LLVMType) (name : String) (v : { fresh : Term, t : Term}) =
   return {p=crucible_null, s=s, t=t};
 };
 
-// Returns a newly-allocated pointer of the given type that points to
-// a new symbolic variable or a term passed in. Also returns the
-// SetupValue and Term for the variable.
+/**
+ * Returns a newly-allocated pointer of the given type that points to
+ * a new symbolic variable or a term passed in. Also returns the
+ * SetupValue and Term for the variable. The first argument is either
+ * CONST or WRITE; see `:h pointer` for more information. The second
+ * argument is type of the value the pointer points to. The third
+ * argument is a name that is printed during debugging or
+ * counterexamples. The fourth argument is either FRESH or STALE; see
+ * `:h variable` for more information.
+ *
+ * For example, the following creates a const array of 4 32-bit
+ * integers assigned the value [1, 2, 3, 4].
+ *
+ *   vs <- alloc CONST (llvm_array 4 uint32_t) "vs" (STALE {{ [1, 2, 3, 4] : [4][32] }})
+ *
+ * The following creates an array of 4 32-bit symbolic integers.
+ *
+ *   vs <- alloc WRITE (llvm_array 4 uint32_t) "vs" FRESH
+ */
 let alloc (rw : Term) (type : LLVMType) (name : String) (v : { fresh : Term, t : Term}) = do {
   v' <- variable type name v;
-  //This pointer cannot is not uninitialized.
-  err <- if (eval_bool {{ rw == 2 }}) then error else noerror;
+  //The UNALLOC pointer cannot point to allocated memory.
+  err <- if (eval_bool {{ rw == UNALLOC }}) then error else noerror;
   p <- pointer rw type;
   points_to p v'.s;
   return {p=p, s=v'.s, t=v'.t};
@@ -92,7 +148,7 @@ let char = llvm_int 8;
 // Provides the type of a struct. For example, 'struct_t "mystruct_t"';
 let struct_t (name : String) = llvm_struct (str_concat "struct." name);
 
-let struct (rw : Term) (struct_name : String) (s : [SetupValue]) = do {
+let struct (s : [SetupValue]) = do {
   let s_struct = crucible_struct s;
   return {p=crucible_null, s=s_struct, t={{ error "struct Term field was accessed" }}};
 };
@@ -122,18 +178,18 @@ let string_t' (size : Int) (string_name : String) = do {
 };
 
 // Provides an empty list of objects. Used as the basecase for
-// `new_init_rec`.
-let new_init_empty = do {
+// `array_init_rec`.
+let array_init_empty = do {
   return {s=[] : [SetupValue], bucket=[] : [b]} : CrucibleSetup {s : [SetupValue], bucket : [b]};
 };
 
 // Provides a list of initialized objects and a same-sized list of
 // buckets where associated values can be stored.
-rec new_init_rec (numElements : Int) (init_function : Int -> a -> CrucibleSetup {s : SetupValue, bucket : b}) (params : a) = do {
+rec array_init_rec (numElements : Int) (init_function : Int -> a -> CrucibleSetup {s : SetupValue, bucket : b}) (params : a) = do {
   err <- if (eval_bool {{ (`numElements : [32]) == 0 }}) then error else noerror; //numElements must be greater than 0
   element <- init_function (eval_int {{ (`numElements : [32]) - 1 }}) params;
-  rest <- if (eval_bool {{ (`numElements : [32]) == 1 }}) then new_init_empty
-          else new_init_rec (eval_int {{ (`numElements : [32]) - 1 }}) init_function params;
+  rest <- if (eval_bool {{ (`numElements : [32]) == 1 }}) then array_init_empty
+          else array_init_rec (eval_int {{ (`numElements : [32]) - 1 }}) init_function params;
 
   let ret_s = (concat rest.s [element.s]);
   let ret_bucket = (concat rest.bucket [element.bucket]);
@@ -141,10 +197,19 @@ rec new_init_rec (numElements : Int) (init_function : Int -> a -> CrucibleSetup 
   return {s=ret_s : [SetupValue], bucket=ret_bucket : [b]};
 };
 
-// Provides an array of initialized objects and a same-sized list of
-// buckets where associated values can be stored.
-let new_init (rw : Term) (numElements : Int) (init_function : Int -> a -> CrucibleSetup {s : SetupValue, bucket : b}) (params : a) (type : LLVMType) = do {
-  list <- new_init_rec numElements init_function params;
+/**
+ * Provides an array of initialized objects and a same-sized list of
+ * buckets where associated values can be stored. The first argument
+ * is either CONST or WRITE; see `:h pointer` for more
+ * information. The second argument is the length of the array. The
+ * third argument is type of the value of the array elements. The
+ * fourth argument is an initialization function that takes the
+ * element's array index and some concrete parameters (the fifth
+ * argument) and returns a SetupValue representing the array and a
+ * bucket where associated values can be stored.
+ */
+let array_init (rw : Term) (numElements : Int) (type : LLVMType) (init_function : Int -> a -> CrucibleSetup {s : SetupValue, bucket : b}) (params : a) = do {
+  list <- array_init_rec numElements init_function params;
   let arr = array list.s;
   p <- pointer rw (llvm_array numElements type);
   points_to p arr;

--- a/common/llvm.saw
+++ b/common/llvm.saw
@@ -112,7 +112,7 @@ let variable (type : LLVMType) (name : String) (v : { fresh : Term, t : Term}) =
  */
 let alloc (rw : Term) (type : LLVMType) (name : String) (v : { fresh : Term, t : Term}) = do {
   v' <- variable type name v;
-  //This pointer cannot is not uninitialized.
+  //This pointer is not uninitialized.
   err <- if (eval_bool {{ rw == 2 }}) then error else noerror;
   p <- pointer rw type;
   points_to p v'.s;

--- a/common/llvm.saw
+++ b/common/llvm.saw
@@ -32,27 +32,58 @@ let CONST  = {{ 0 : [2] }}; //Points to allocated space that is READ ONLY.
 let WRITE  = {{ 1 : [2] }}; //Points to allocated space that can be modified.
 let UNINIT = {{ 2 : [2] }}; //Pointer does not point to allocated space.
 
-// Returns a pointer of the given type.
+/**
+ * Returns a pointer of the given type. The first argument is either
+ * CONST, WRITE, or UNINT. The second argument is the type of the
+ * value the pointer can point to.
+ *
+ * For example, the following creates a pointer to allocated space
+ * that is read only.
+ *
+ *   p <- pointer CONST
+ *
+ * The following creates a pointer to allocated space that can be
+ * modified.
+ *
+ *   p <- pointer WRITE
+ *
+ *
+ * The following creates a pointer that is either uninitialized or
+ * NULL, i.e. that does not point to allocated space.
+ *
+ *   p <- pointer UNINIT
+ */ 
 let pointer (rw : Term) (type : LLVMType) =
-  if     (eval_bool {{ rw == 0 }}) then crucible_alloc_readonly type
-  else if(eval_bool {{ rw == 1 }}) then crucible_alloc type
-  else                                  crucible_fresh_pointer type;
+  if (eval_bool {{ rw == 0 }}) then crucible_alloc_readonly type
+  else if (eval_bool {{ rw == 1 }}) then crucible_alloc type
+  else crucible_fresh_pointer type;
 
 //Symbolic value --- for use with the `variable` function.
-let FRESH   = { fresh={{ True }} : Term, t={{ error "NEW Term field was accessed" }} : Term};
+let FRESH = { fresh={{ True }} : Term, t={{ error "NEW Term field was accessed" }} : Term};
 //Concrete value --- for use with the `variable` function.
 let STALE (t : Term) = { fresh={{ False }} : Term, t=t : Term};
 
+//Empty variable --- called by the `variable` function.
 let variable_empty = do {
   return {{ False }};
 };
 
-// Returns a NULL pointer, the SetupValue, and a Term for either a new
-// symbolic variable or a term passed in.
-// Should be called like:
-//   variable "name" (llvm_int 32) SYM;
-// or
-//   variable "name" (llvm_int 32) (CON {{ 10 : [32] }});
+/**
+ * Returns a NULL pointer, SetupValue, and Term for either a new
+ * symbolic variable or a term passed in. The first argument is the
+ * type of the variable to be created. The second argument is a name
+ * that is printed during debugging or counterexamples. The third
+ * argument is either FRESH or STALE.
+ *
+ * For example, the following creates a 32-bit variable that can take
+ * on any 32-bit value.
+ *
+ *   v <- variable (llvm_int 32) "name" FRESH
+ *
+ * The following creates a 32-bit variable assigned to 10.
+ *
+ *   v <- variable (llvm_int 32) "name" (STALE {{ 10 : [32] }})
+ */
 let variable (type : LLVMType) (name : String) (v : { fresh : Term, t : Term}) = do {
   cfv <- if (eval_bool v.fresh) then (crucible_fresh_var name type) else variable_empty;
   let t = if (eval_bool v.fresh) then cfv else v.t;
@@ -60,9 +91,25 @@ let variable (type : LLVMType) (name : String) (v : { fresh : Term, t : Term}) =
   return {p=crucible_null, s=s, t=t};
 };
 
-// Returns a newly-allocated pointer of the given type that points to
-// a new symbolic variable or a term passed in. Also returns the
-// SetupValue and Term for the variable.
+/**
+ * Returns a newly-allocated pointer of the given type that points to
+ * a new symbolic variable or a term passed in. Also returns the
+ * SetupValue and Term for the variable. The first argument is either
+ * CONST or WRITE; see `:h pointer` for more information. The second
+ * argument is type of the value the pointer points to. The third
+ * argument is a name that is printed during debugging or
+ * counterexamples. The fourth argument is either FRESH or STALE; see
+ * `:h variable` for more information.
+ *
+ * For example, the following creates a const array of 4 32-bit
+ * integers assigned the value [1, 2, 3, 4].
+ *
+ *   vs <- alloc CONST (llvm_array 4 uint32_t) "vs" (STALE {{ [1, 2, 3, 4] : [4][32] }})
+ *
+ * The following creates an array of 4 32-bit symbolic integers.
+ *
+ *   vs <- alloc WRITE (llvm_array 4 uint32_t) "vs" FRESH
+ */
 let alloc (rw : Term) (type : LLVMType) (name : String) (v : { fresh : Term, t : Term}) = do {
   v' <- variable type name v;
   //This pointer cannot is not uninitialized.
@@ -92,7 +139,7 @@ let char = llvm_int 8;
 // Provides the type of a struct. For example, 'struct_t "mystruct_t"';
 let struct_t (name : String) = llvm_struct (str_concat "struct." name);
 
-let struct (rw : Term) (struct_name : String) (s : [SetupValue]) = do {
+let struct (s : [SetupValue]) = do {
   let s_struct = crucible_struct s;
   return {p=crucible_null, s=s_struct, t={{ error "struct Term field was accessed" }}};
 };
@@ -122,18 +169,18 @@ let string_t' (size : Int) (string_name : String) = do {
 };
 
 // Provides an empty list of objects. Used as the basecase for
-// `new_init_rec`.
-let new_init_empty = do {
+// `array_init_rec`.
+let array_init_empty = do {
   return {s=[] : [SetupValue], bucket=[] : [b]} : CrucibleSetup {s : [SetupValue], bucket : [b]};
 };
 
 // Provides a list of initialized objects and a same-sized list of
 // buckets where associated values can be stored.
-rec new_init_rec (numElements : Int) (init_function : Int -> a -> CrucibleSetup {s : SetupValue, bucket : b}) (params : a) = do {
+rec array_init_rec (numElements : Int) (init_function : Int -> a -> CrucibleSetup {s : SetupValue, bucket : b}) (params : a) = do {
   err <- if (eval_bool {{ (`numElements : [32]) == 0 }}) then error else noerror; //numElements must be greater than 0
   element <- init_function (eval_int {{ (`numElements : [32]) - 1 }}) params;
-  rest <- if (eval_bool {{ (`numElements : [32]) == 1 }}) then new_init_empty
-          else new_init_rec (eval_int {{ (`numElements : [32]) - 1 }}) init_function params;
+  rest <- if (eval_bool {{ (`numElements : [32]) == 1 }}) then array_init_empty
+          else array_init_rec (eval_int {{ (`numElements : [32]) - 1 }}) init_function params;
 
   let ret_s = (concat rest.s [element.s]);
   let ret_bucket = (concat rest.bucket [element.bucket]);
@@ -141,10 +188,19 @@ rec new_init_rec (numElements : Int) (init_function : Int -> a -> CrucibleSetup 
   return {s=ret_s : [SetupValue], bucket=ret_bucket : [b]};
 };
 
-// Provides an array of initialized objects and a same-sized list of
-// buckets where associated values can be stored.
-let new_init (rw : Term) (numElements : Int) (init_function : Int -> a -> CrucibleSetup {s : SetupValue, bucket : b}) (params : a) (type : LLVMType) = do {
-  list <- new_init_rec numElements init_function params;
+/**
+ * Provides an array of initialized objects and a same-sized list of
+ * buckets where associated values can be stored. The first argument
+ * is either CONST or WRITE; see `:h pointer` for more
+ * information. The second argument is the length of the array. The
+ * third argument is type of the value of the array elements. The
+ * fourth argument is an initialization function that takes the
+ * element's array index and some concrete parameters (the fifth
+ * argument) and returns a SetupValue representing the array and a
+ * bucket where associated values can be stored.
+ */
+let array_init (rw : Term) (numElements : Int) (type : LLVMType) (init_function : Int -> a -> CrucibleSetup {s : SetupValue, bucket : b}) (params : a) = do {
+  list <- array_init_rec numElements init_function params;
   let arr = array list.s;
   p <- pointer rw (llvm_array numElements type);
   points_to p arr;

--- a/common/llvm.saw
+++ b/common/llvm.saw
@@ -4,10 +4,10 @@
 let points_to = crucible_points_to;
 let precond = crucible_precond;
 let from_cryptol = crucible_term;
+
 let execute = crucible_execute_func;
 let postcond = crucible_postcond;
 let returns = crucible_return;
-let struct = crucible_struct;
 let array = crucible_array;
 let llvm_verify module function_name overrides spec =
   crucible_llvm_verify module function_name overrides true spec z3;
@@ -67,6 +67,13 @@ let char = llvm_int 8;
 
 // Provides the type of a struct. For example, 'struct_t "mystruct_t"';
 let struct_t (name : String) = llvm_struct (str_concat "struct." name);
+
+let struct (s : [SetupValue]) struct_name rw = do {
+  let s_struct = crucible_struct s;
+  p_struct <- pointer rw (struct_t struct_name);
+  points_to p_struct s_struct;
+  return {p=p_struct, s=s_struct};
+};
 
 // Provides a pointer, SetupValue, and Term associated with a string
 // of size `size+1` that is NULL terminated. The Term (Cryptol value)

--- a/common/llvm.saw
+++ b/common/llvm.saw
@@ -39,6 +39,15 @@ let alloc (name : String) (rw : Term) (type : LLVMType) = do {
   return {p=p, s=v.s, t=v.t};
 };
 
+// Returns a newly-allocated pointer of the given type that points to
+// a given symbolic variable. Also returns the SetupValue and Term for
+// the variable.
+let alloc_init (name : String) (rw : Term) (type : LLVMType) (v : SetupValue) = do {
+  p <- pointer rw type;
+  points_to p v;
+  return {p=p, s=v};
+};
+
 // Standard LLVM type names
 let i8 = llvm_int 8;
 let i16 = llvm_int 16;

--- a/common/llvm.saw
+++ b/common/llvm.saw
@@ -1,5 +1,19 @@
 // LLVM utility definitions
 
+// This function will cause llvm_verify to error and, most
+// importantly, provide a handy backtrace.
+let error = do {
+  crucible_precond {{ True }};
+  crucible_postcond {{ True }};
+  return {{ True }};
+};
+
+// This function is useful in the opposite case of an `if` statement
+// with an `error`.
+let noerror = do {
+  return {{ True }};
+};
+
 // Remove 'crucible' from common commands
 let points_to = crucible_points_to;
 let precond = crucible_precond;
@@ -14,13 +28,15 @@ let llvm_verify module function_name overrides spec =
 
 // Declare constants used to denote whether an allocation is
 // 'READONLY' (CONST) or not (WRITE).
-let CONST = {{ False }};
-let WRITE = {{ True }};
+let CONST  = {{ 0 : [2] }}; //Points to allocated space that is READ ONLY.
+let WRITE  = {{ 1 : [2] }}; //Points to allocated space that can be modified.
+let UNINIT = {{ 2 : [2] }}; //Pointer does not point to allocated space.
 
 // Returns a newly-allocated pointer of the given type.
-let pointer (rw : Term) (type : LLVMType) = if (eval_bool {{ rw == WRITE }})
-                      then crucible_alloc type
-                      else crucible_alloc_readonly type;
+let pointer (rw : Term) (type : LLVMType) =
+  if     (eval_bool {{ rw == 0 }}) then crucible_alloc_readonly type
+  else if(eval_bool {{ rw == 1 }}) then crucible_alloc type
+  else                                  crucible_fresh_pointer type;
 
 //Symbolic value --- for use with the `variable` function.
 let FRESH   = { fresh={{ True }} : Term, t={{ error "NEW Term field was accessed" }} : Term};
@@ -49,6 +65,8 @@ let variable (type : LLVMType) (name : String) (v : { fresh : Term, t : Term}) =
 // SetupValue and Term for the variable.
 let alloc (rw : Term) (type : LLVMType) (name : String) (v : { fresh : Term, t : Term}) = do {
   v' <- variable type name v;
+  //This pointer cannot is not uninitialized.
+  err <- if (eval_bool {{ rw == 2 }}) then error else noerror;
   p <- pointer rw type;
   points_to p v'.s;
   return {p=p, s=v'.s, t=v'.t};
@@ -101,20 +119,6 @@ let string_t' (size : Int) (string_name : String) = do {
   let s = string.t;
   postcond {{ s@(`size : [64]) == 0 }};
   return {p=string.p, s=from_cryptol string.t, t=string.t};
-};
-
-// This function will cause llvm_verify to error and, most
-// importantly, provide a handy backtrace.
-let error = do {
-  crucible_precond {{ True }};
-  crucible_postcond {{ True }};
-  return {{ True }};
-};
-
-// This function is useful in the opposite case of an `if` statement
-// with an `error`.
-let noerror = do {
-  return {{ True }};
 };
 
 // Provides an empty list of objects. Used as the basecase for

--- a/common/llvm.saw
+++ b/common/llvm.saw
@@ -1,28 +1,42 @@
 // LLVM utility definitions
 
+// Remove 'crucible' from common commands
+let points_to = crucible_points_to;
+let precond = crucible_precond;
+let from_cryptol = crucible_term;
+let execute = crucible_execute_func;
+let postcond = crucible_postcond;
+let returns = crucible_return;
+let struct = crucible_struct;
+let array = crucible_array;
+let llvm_verify module function_name overrides spec =
+  crucible_llvm_verify module function_name overrides true spec z3;
+
+// Declare constants used to denote whether an allocation is
+// 'READONLY' (CONST) or not (WRITE).
+let CONST = {{ False }};
+let WRITE = {{ True }};
+
+// Returns a newly-allocated pointer of the given type.
+let pointer (rw : Term) (type : LLVMType) = if (eval_bool {{ rw == WRITE }})
+                      then crucible_alloc type
+                      else crucible_alloc_readonly type;
+
+// Returns both the SetupValue and a Term for a new symbolic
+// variable.
+let variable (name : String) (type : LLVMType) = do {
+  cryptol_var <- crucible_fresh_var name type;
+  return {s=from_cryptol cryptol_var : SetupValue, t=cryptol_var : Term};
+};
+
 // Returns a newly-allocated pointer of the given type that points to
-// the given value.
-let alloc_init ty v = do {
-    p <- crucible_alloc ty;
-    crucible_points_to p v;
-    return p;
-};
-
-// Returns a fresh value of the given type along with a newly-allocated
-// pointer that points to that value.
-let ptr_to_fresh n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- alloc_init ty (crucible_term x);
-    return (x, p);
-};
-
-// Returns a fresh value of the given type along with a newly-allocated
-// read-only pointer that points to that value.
-let ptr_to_fresh_readonly n ty = do {
-    x <- crucible_fresh_var n ty;
-    p <- crucible_alloc_readonly ty;
-    crucible_points_to p (crucible_term x);
-    return (x, p);
+// a new symbolic variable. Also returns the SetupValue and Term for
+// the variable.
+let alloc (name : String) (rw : Term) (type : LLVMType) = do {
+  p <- pointer rw type;
+  v <- variable name type;
+  points_to p v.s;
+  return {p=p, s=v.s, t=v.t};
 };
 
 // Standard LLVM type names
@@ -36,5 +50,77 @@ let int8_t = llvm_int 8;
 let int16_t = llvm_int 16;
 let int32_t = llvm_int 32;
 let int64_t = llvm_int 64;
+let uint8_t = llvm_int 8;
+let uint16_t = llvm_int 16;
+let uint32_t = llvm_int 32;
+let uint64_t = llvm_int 64;
+let char = llvm_int 8;
 
-let bytes n = llvm_array n i8;
+// Provides the type of a struct. For example, 'struct_t "mystruct_t"';
+let struct_t (name : String) = llvm_struct (str_concat "struct." name);
+
+// Provides a pointer, SetupValue, and Term associated with a string
+// of size `size+1` that is NULL terminated. The Term (Cryptol value)
+// DOES NOT have the NULL at the end of the string.
+// This is to be used before the `execute` command.
+let string_t (string_name : String) (rw : Term) (size : Int) = do {
+  string <- crucible_fresh_var string_name (llvm_array size uint8_t);
+  pstring <- pointer rw (llvm_array (eval_int {{ `size + 1 : [64] }}) uint8_t);
+  points_to pstring (from_cryptol {{ string # [0] }});
+  return {p=pstring, s=from_cryptol string, t=string};
+};
+
+// Provides a pointer, SetupValue, and Term associated with a string
+// of size `size+1` that is NULL terminated. The Term (Cryptol value)
+// DOES have the NULL at the end of the string.
+// This is to be used after the `execute` command.
+
+let string_t' (string_name : String) (size : Int) = do {
+  string <- alloc "string" CONST (llvm_array (eval_int {{ `(size+1) : [64] }}) uint8_t);
+  let s = string.t;
+  postcond {{ s@(`size : [64]) == 0 }};
+  return {p=string.p, s=from_cryptol string.t, t=string.t};
+};
+
+// This function will cause llvm_verify to error and, most
+// importantly, provide a handy backtrace.
+let error = do {
+  crucible_precond {{ True }};
+  crucible_postcond {{ True }};
+  return {{ True }};
+};
+
+// This function is useful in the opposite case of an `if` statement
+// with an `error`.
+let noerror = do {
+  return {{ True }};
+};
+
+// Provides an empty list of structures. Used as the basecase for `struct_list_rec`.
+let struct_list_empty = do {
+  return {s=[] : [SetupValue], bucket=[] : [b]} : CrucibleSetup {s : [SetupValue], bucket : [b]};
+};
+
+// Provides a list of initialized structs and a same-sized list of
+// buckets where associated values can be stored.
+rec struct_list_rec (numElements : Int) (init_function : Int -> a -> CrucibleSetup {s : SetupValue, bucket : b}) (params : a) = do {
+  err <- if (eval_bool {{ (`numElements : [32]) == 0 }}) then error else noerror; //numElements must be greater than 0
+  element <- init_function (eval_int {{ (`numElements : [32]) - 1 }}) params;
+  rest <- if (eval_bool {{ (`numElements : [32]) == 1 }}) then struct_list_empty
+          else struct_list_rec (eval_int {{ (`numElements : [32]) - 1 }}) init_function params;
+
+  let ret_s = (concat rest.s [element.s]);
+  let ret_bucket = (concat rest.bucket [element.bucket]);
+
+  return {s=ret_s : [SetupValue], bucket=ret_bucket : [b]};
+};
+
+// Provides an array of initialized structs and a same-sized list of
+// buckets where associated values can be stored.
+let struct_array (rw : Term) (numElements : Int) (init_function : Int -> a -> CrucibleSetup {s : SetupValue, bucket : b}) (params : a) (type : LLVMType) = do {
+  list <- struct_list_rec numElements init_function params;
+  let arr = array list.s;
+  p <- pointer rw (llvm_array numElements type);
+  points_to p arr;
+  return {p=p : SetupValue, s=arr : SetupValue, bucket=list.bucket : [b]};
+};

--- a/common/llvm.saw
+++ b/common/llvm.saw
@@ -23,9 +23,13 @@ let pointer (rw : Term) (type : LLVMType) = if (eval_bool {{ rw == WRITE }})
                       else crucible_alloc_readonly type;
 
 //Symbolic value --- for use with the `variable` function.
-let SYM   = { symbolic={{ True }} : Term, t={{ False }} : Term};
+let FRESH   = { fresh={{ True }} : Term, t={{ error "NEW Term field was accessed" }} : Term};
 //Concrete value --- for use with the `variable` function.
-let CON t = { symbolic={{ False }} : Term, t=t : Term};
+let STALE (t : Term) = { fresh={{ False }} : Term, t=t : Term};
+
+let variable_empty = do {
+  return {{ False }};
+};
 
 // Returns a NULL pointer, the SetupValue, and a Term for either a new
 // symbolic variable or a term passed in.
@@ -33,29 +37,21 @@ let CON t = { symbolic={{ False }} : Term, t=t : Term};
 //   variable "name" (llvm_int 32) SYM;
 // or
 //   variable "name" (llvm_int 32) (CON {{ 10 : [32] }});
-let variable (name : String) (type : LLVMType) (v : { symbolic : Term, t : Term}) = do {
-  cfv <- crucible_fresh_var name type;
-  let t = if (eval_bool v.symbolic) then cfv else v.t;
-  return {p=crucible_null, s=from_cryptol t, t=t};
+let variable (type : LLVMType) (name : String) (v : { fresh : Term, t : Term}) = do {
+  cfv <- if (eval_bool v.fresh) then (crucible_fresh_var name type) else variable_empty;
+  let t = if (eval_bool v.fresh) then cfv else v.t;
+  let s = from_cryptol t;
+  return {p=crucible_null, s=s, t=t};
 };
 
 // Returns a newly-allocated pointer of the given type that points to
-// a new symbolic variable. Also returns the SetupValue and Term for
-// the variable.
-let alloc (name : String) (rw : Term) (type : LLVMType) = do {
+// a new symbolic variable or a term passed in. Also returns the
+// SetupValue and Term for the variable.
+let alloc (rw : Term) (type : LLVMType) (name : String) (v : { fresh : Term, t : Term}) = do {
+  v' <- variable type name v;
   p <- pointer rw type;
-  v <- variable name type SYM;
-  points_to p v.s;
-  return {p=p, s=v.s, t=v.t};
-};
-
-// Returns a newly-allocated pointer of the given type that points to
-// a given variable : SetupValue. Also returns the SetupValue and Term for
-// the variable.
-let alloc_init (name : String) (rw : Term) (type : LLVMType) (v : {p : SetupValue, s : SetupValue, t : Term}) = do {
-  p <- pointer rw type;
-  points_to p v.s;
-  return {p=p, s=v.s, t=v.t};
+  points_to p v'.s;
+  return {p=p, s=v'.s, t=v'.t};
 };
 
 // Standard LLVM type names
@@ -78,22 +74,21 @@ let char = llvm_int 8;
 // Provides the type of a struct. For example, 'struct_t "mystruct_t"';
 let struct_t (name : String) = llvm_struct (str_concat "struct." name);
 
-let struct struct_name rw (s : [SetupValue]) = do {
+let struct (rw : Term) (struct_name : String) (s : [SetupValue]) = do {
   let s_struct = crucible_struct s;
-  p_struct <- pointer rw (struct_t struct_name);
-  points_to p_struct s_struct;
-  return {p=p_struct, s=s_struct, t={{ zero }}};
+  return {p=crucible_null, s=s_struct, t={{ error "struct Term field was accessed" }}};
 };
 
 // Provides a pointer, SetupValue, and Term associated with a string
 // of size `size+1` that is NULL terminated. The Term (Cryptol value)
 // DOES NOT have the NULL at the end of the string.
 // This is to be used before the `execute` command.
-let string_t (string_name : String) (rw : Term) (size : Int) = do {
-  string <- crucible_fresh_var string_name (llvm_array size uint8_t);
+let string_t (rw : Term) (size : Int) (string_name : String) = do {
+  string <- variable (llvm_array size uint8_t) string_name FRESH;
   pstring <- pointer rw (llvm_array (eval_int {{ `size + 1 : [64] }}) uint8_t);
-  points_to pstring (from_cryptol {{ string # [0] }});
-  return {p=pstring, s=from_cryptol string, t=string};
+  let stringt = string.t;
+  points_to pstring (from_cryptol {{ stringt # [0] }});
+  return {p=pstring, s=string.s, t=string.t};
 };
 
 // Provides a pointer, SetupValue, and Term associated with a string
@@ -101,8 +96,8 @@ let string_t (string_name : String) (rw : Term) (size : Int) = do {
 // DOES have the NULL at the end of the string.
 // This is to be used after the `execute` command.
 
-let string_t' (string_name : String) (size : Int) = do {
-  string <- alloc "string" CONST (llvm_array (eval_int {{ `(size+1) : [64] }}) uint8_t);
+let string_t' (size : Int) (string_name : String) = do {
+  string <- alloc CONST (llvm_array (eval_int {{ `(size+1) : [64] }}) uint8_t) "string" FRESH;
   let s = string.t;
   postcond {{ s@(`size : [64]) == 0 }};
   return {p=string.p, s=from_cryptol string.t, t=string.t};
@@ -122,18 +117,19 @@ let noerror = do {
   return {{ True }};
 };
 
-// Provides an empty list of structures. Used as the basecase for `struct_list_rec`.
-let struct_list_empty = do {
+// Provides an empty list of objects. Used as the basecase for
+// `new_init_rec`.
+let new_init_empty = do {
   return {s=[] : [SetupValue], bucket=[] : [b]} : CrucibleSetup {s : [SetupValue], bucket : [b]};
 };
 
-// Provides a list of initialized structs and a same-sized list of
+// Provides a list of initialized objects and a same-sized list of
 // buckets where associated values can be stored.
-rec struct_list_rec (numElements : Int) (init_function : Int -> a -> CrucibleSetup {s : SetupValue, bucket : b}) (params : a) = do {
+rec new_init_rec (numElements : Int) (init_function : Int -> a -> CrucibleSetup {s : SetupValue, bucket : b}) (params : a) = do {
   err <- if (eval_bool {{ (`numElements : [32]) == 0 }}) then error else noerror; //numElements must be greater than 0
   element <- init_function (eval_int {{ (`numElements : [32]) - 1 }}) params;
-  rest <- if (eval_bool {{ (`numElements : [32]) == 1 }}) then struct_list_empty
-          else struct_list_rec (eval_int {{ (`numElements : [32]) - 1 }}) init_function params;
+  rest <- if (eval_bool {{ (`numElements : [32]) == 1 }}) then new_init_empty
+          else new_init_rec (eval_int {{ (`numElements : [32]) - 1 }}) init_function params;
 
   let ret_s = (concat rest.s [element.s]);
   let ret_bucket = (concat rest.bucket [element.bucket]);
@@ -141,10 +137,10 @@ rec struct_list_rec (numElements : Int) (init_function : Int -> a -> CrucibleSet
   return {s=ret_s : [SetupValue], bucket=ret_bucket : [b]};
 };
 
-// Provides an array of initialized structs and a same-sized list of
+// Provides an array of initialized objects and a same-sized list of
 // buckets where associated values can be stored.
-let struct_array (rw : Term) (numElements : Int) (init_function : Int -> a -> CrucibleSetup {s : SetupValue, bucket : b}) (params : a) (type : LLVMType) = do {
-  list <- struct_list_rec numElements init_function params;
+let new_init (rw : Term) (numElements : Int) (init_function : Int -> a -> CrucibleSetup {s : SetupValue, bucket : b}) (params : a) (type : LLVMType) = do {
+  list <- new_init_rec numElements init_function params;
   let arr = array list.s;
   p <- pointer rw (llvm_array numElements type);
   points_to p arr;

--- a/common/llvm.saw
+++ b/common/llvm.saw
@@ -63,9 +63,9 @@ let UNALLOC = {{ 2 : [2] }}; //Pointer does not point to allocated space.
  *   p <- pointer UNALLOC (llvm_array 4 uint32_t);
  */ 
 let pointer (rw : Term) (type : LLVMType) =
-  if (eval_bool {{ rw == CONST }}) then crucible_alloc_readonly type
+  if      (eval_bool {{ rw == CONST }}) then crucible_alloc_readonly type
   else if (eval_bool {{ rw == WRITE }}) then crucible_alloc type
-  else crucible_fresh_pointer type;
+  else                                       crucible_fresh_pointer type;
 
 //Symbolic value --- for use with the `variable` function.
 let FRESH = { fresh={{ True }} : Term, t={{ error "NEW Term field was accessed" }} : Term};

--- a/common/llvm.saw
+++ b/common/llvm.saw
@@ -26,13 +26,13 @@ let array = crucible_array;
 let llvm_verify module function_name overrides spec =
   crucible_llvm_verify module function_name overrides true spec z3;
 
-// Declare constants used to denote whether an allocation is
-// 'READONLY' (CONST) or not (WRITE).
+// Declare constants used to denote what kind of space a pointer is
+// pointing to.
 let CONST  = {{ 0 : [2] }}; //Points to allocated space that is READ ONLY.
 let WRITE  = {{ 1 : [2] }}; //Points to allocated space that can be modified.
 let UNINIT = {{ 2 : [2] }}; //Pointer does not point to allocated space.
 
-// Returns a newly-allocated pointer of the given type.
+// Returns a pointer of the given type.
 let pointer (rw : Term) (type : LLVMType) =
   if     (eval_bool {{ rw == 0 }}) then crucible_alloc_readonly type
   else if(eval_bool {{ rw == 1 }}) then crucible_alloc type

--- a/common/llvm.saw
+++ b/common/llvm.saw
@@ -22,11 +22,21 @@ let pointer (rw : Term) (type : LLVMType) = if (eval_bool {{ rw == WRITE }})
                       then crucible_alloc type
                       else crucible_alloc_readonly type;
 
-// Returns both the SetupValue and a Term for a new symbolic
-// variable.
-let variable (name : String) (type : LLVMType) = do {
-  cryptol_var <- crucible_fresh_var name type;
-  return {s=from_cryptol cryptol_var : SetupValue, t=cryptol_var : Term};
+//Symbolic value --- for use with the `variable` function.
+let SYM   = { symbolic={{ True }} : Term, t={{ False }} : Term};
+//Concrete value --- for use with the `variable` function.
+let CON t = { symbolic={{ False }} : Term, t=t : Term};
+
+// Returns a NULL pointer, the SetupValue, and a Term for either a new
+// symbolic variable or a term passed in.
+// Should be called like:
+//   variable "name" (llvm_int 32) SYM;
+// or
+//   variable "name" (llvm_int 32) (CON {{ 10 : [32] }});
+let variable (name : String) (type : LLVMType) (v : { symbolic : Term, t : Term}) = do {
+  cfv <- crucible_fresh_var name type;
+  let t = if (eval_bool v.symbolic) then cfv else v.t;
+  return {p=crucible_null, s=from_cryptol t, t=t};
 };
 
 // Returns a newly-allocated pointer of the given type that points to
@@ -34,18 +44,18 @@ let variable (name : String) (type : LLVMType) = do {
 // the variable.
 let alloc (name : String) (rw : Term) (type : LLVMType) = do {
   p <- pointer rw type;
-  v <- variable name type;
+  v <- variable name type SYM;
   points_to p v.s;
   return {p=p, s=v.s, t=v.t};
 };
 
 // Returns a newly-allocated pointer of the given type that points to
-// a given symbolic variable. Also returns the SetupValue and Term for
+// a given variable : SetupValue. Also returns the SetupValue and Term for
 // the variable.
-let alloc_init (name : String) (rw : Term) (type : LLVMType) (v : SetupValue) = do {
+let alloc_init (name : String) (rw : Term) (type : LLVMType) (v : {p : SetupValue, s : SetupValue, t : Term}) = do {
   p <- pointer rw type;
-  points_to p v;
-  return {p=p, s=v};
+  points_to p v.s;
+  return {p=p, s=v.s, t=v.t};
 };
 
 // Standard LLVM type names
@@ -68,11 +78,11 @@ let char = llvm_int 8;
 // Provides the type of a struct. For example, 'struct_t "mystruct_t"';
 let struct_t (name : String) = llvm_struct (str_concat "struct." name);
 
-let struct (s : [SetupValue]) struct_name rw = do {
+let struct struct_name rw (s : [SetupValue]) = do {
   let s_struct = crucible_struct s;
   p_struct <- pointer rw (struct_t struct_name);
   points_to p_struct s_struct;
-  return {p=p_struct, s=s_struct};
+  return {p=p_struct, s=s_struct, t={{ zero }}};
 };
 
 // Provides a pointer, SetupValue, and Term associated with a string

--- a/demos/salsa20/salsa20.saw
+++ b/demos/salsa20/salsa20.saw
@@ -4,27 +4,30 @@ import "../../cryptol-specs/Primitive/Symmetric/Cipher/Stream/Salsa20.cry";
 
 let prover nm = abc;
 
+let bytes n = (llvm_array n uint8_t);
 let words n = llvm_array n i32;
 
 let oneptr_update_func n ty f = do {
-    (x, p) <- ptr_to_fresh n ty;
-    crucible_execute_func [p];
-    crucible_points_to p (crucible_term {{ f x }});
+    v <- alloc n WRITE ty;
+    execute [v.p];
+    let t = v.t;
+    points_to v.p (from_cryptol {{ f t }});
 };
 
 let quarterround_setup = do {
-    (y0, p0) <- ptr_to_fresh "y0" i32;
-    (y1, p1) <- ptr_to_fresh "y1" i32;
-    (y2, p2) <- ptr_to_fresh "y2" i32;
-    (y3, p3) <- ptr_to_fresh "y3" i32;
+    y0 <- alloc "y0" WRITE i32;
+    y1 <- alloc "y1" WRITE i32;
+    y2 <- alloc "y2" WRITE i32;
+    y3 <- alloc "y3" WRITE i32;
 
-    crucible_execute_func [p0, p1, p2, p3];
+    execute [y0.p, y1.p, y2.p, y3.p];
 
-    let zs = {{ quarterround [y0,y1,y2,y3] }};
-    crucible_points_to p0 (crucible_term {{ zs@0 }});
-    crucible_points_to p1 (crucible_term {{ zs@1 }});
-    crucible_points_to p2 (crucible_term {{ zs@2 }});
-    crucible_points_to p3 (crucible_term {{ zs@3 }});
+    let (y0t, y1t, y2t, y3t) = (y0.t, y1.t, y2.t, y3.t);
+    let zs = {{ quarterround [y0t,y1t,y2t,y3t] }};
+    points_to y0.p (from_cryptol {{ zs@0 }});
+    points_to y1.p (from_cryptol {{ zs@1 }});
+    points_to y2.p (from_cryptol {{ zs@2 }});
+    points_to y3.p (from_cryptol {{ zs@3 }});
 };
 
 let rowround_setup =
@@ -40,27 +43,29 @@ let salsa20_setup =
     oneptr_update_func "seq" (bytes 64) {{ Salsa20 }};
 
 let salsa20_expansion_32 = do {
-    (k, pk) <- ptr_to_fresh_readonly "k" (bytes 32);
-    (n, pn) <- ptr_to_fresh_readonly "n" (bytes 16);
-    pks     <- crucible_alloc            (bytes 64);
+    k <- alloc "k" CONST (bytes 32);
+    n <- alloc "n" CONST (bytes 16);
+    pks <- pointer WRITE (bytes 64);
 
-    crucible_execute_func [pk, pn, pks];
+    execute [k.p, n.p, pks];
 
-    let rks = {{ Salsa20_expansion`{a=2}(k, n)}};
-    crucible_points_to pks (crucible_term rks);
+    let (kt, nt) = (k.t, n.t);
+    let rks = {{ Salsa20_expansion`{a=2}(kt, nt)}};
+    points_to pks (from_cryptol rks);
 };
 
 let s20_encrypt32 n = do {
-    let zerot = crucible_term {{ 0 : [32] }};
-    let nt = crucible_term {{ `n : [32] }};
-    (key, pkey) <- ptr_to_fresh "key"   (bytes 32);
-    (v, pv)     <- ptr_to_fresh "nonce" (bytes 8);
-    (m, pm)     <- ptr_to_fresh "buf"   (bytes n);
+    let zerot = from_cryptol {{ 0 : [32] }};
+    let nt = from_cryptol {{ `n : [32] }};
+    key <- alloc "key" CONST (bytes 32);
+    v <- alloc "nonce" CONST (bytes 8);
+    m <- alloc "buf" WRITE (bytes n);
+    
+    execute [key.p, v.p, zerot, m.p, nt];
 
-    crucible_execute_func [pkey, pv, zerot, pm, nt];
-
-    crucible_points_to pm (crucible_term {{ Salsa20_encrypt (key, v, m) }});
-    crucible_return zerot;
+    let (keyt, vt, mt) = (key.t, v.t, m.t);
+    points_to m.p (from_cryptol {{ Salsa20_encrypt (keyt, vt, mt) }});
+    returns zerot;
 };
 
 m <- llvm_load_module "salsa20.bc";

--- a/demos/salsa20/salsa20.saw
+++ b/demos/salsa20/salsa20.saw
@@ -8,17 +8,17 @@ let bytes n = (llvm_array n uint8_t);
 let words n = llvm_array n i32;
 
 let oneptr_update_func n ty f = do {
-    v <- alloc n WRITE ty;
+    v <- alloc WRITE ty n FRESH;
     execute [v.p];
     let t = v.t;
     points_to v.p (from_cryptol {{ f t }});
 };
 
 let quarterround_setup = do {
-    y0 <- alloc "y0" WRITE i32;
-    y1 <- alloc "y1" WRITE i32;
-    y2 <- alloc "y2" WRITE i32;
-    y3 <- alloc "y3" WRITE i32;
+    y0 <- alloc WRITE i32 "y0" FRESH;
+    y1 <- alloc WRITE i32 "y1" FRESH;
+    y2 <- alloc WRITE i32 "y2" FRESH;
+    y3 <- alloc WRITE i32 "y3" FRESH;
 
     execute [y0.p, y1.p, y2.p, y3.p];
 
@@ -43,8 +43,8 @@ let salsa20_setup =
     oneptr_update_func "seq" (bytes 64) {{ Salsa20 }};
 
 let salsa20_expansion_32 = do {
-    k <- alloc "k" CONST (bytes 32);
-    n <- alloc "n" CONST (bytes 16);
+    k <- alloc CONST (bytes 32) "k" FRESH;
+    n <- alloc CONST (bytes 16) "n" FRESH;
     pks <- pointer WRITE (bytes 64);
 
     execute [k.p, n.p, pks];
@@ -57,9 +57,9 @@ let salsa20_expansion_32 = do {
 let s20_encrypt32 n = do {
     let zerot = from_cryptol {{ 0 : [32] }};
     let nt = from_cryptol {{ `n : [32] }};
-    key <- alloc "key" CONST (bytes 32);
-    v <- alloc "nonce" CONST (bytes 8);
-    m <- alloc "buf" WRITE (bytes n);
+    key <- alloc CONST (bytes 32) "key" FRESH;
+    v <- alloc CONST (bytes 8) "nonce" FRESH;
+    m <- alloc WRITE (bytes n) "buf" FRESH;
     
     execute [key.p, v.p, zerot, m.p, nt];
 

--- a/templates/c/dotprod.saw
+++ b/templates/c/dotprod.saw
@@ -7,26 +7,28 @@ include "../../common/llvm.saw";
 // This function specifies what the `dotprod` function should do when
 // given an input of size `n`.
 let dotprod_spec n = do {
-    let nt = crucible_term {{ `n : [32] }};
-    (xs, xsp) <- ptr_to_fresh "xs" (llvm_array n i32);
-    (ys, ysp) <- ptr_to_fresh "ys" (llvm_array n i32);
-    let xval = crucible_struct [ xsp, nt ];
-    let yval = crucible_struct [ ysp, nt ];
-    xp <- alloc_init (llvm_struct "struct.vec_t") xval;
-    yp <- alloc_init (llvm_struct "struct.vec_t") yval;
-    crucible_execute_func [xp, yp];
-    crucible_return (crucible_term {{ dotprod xs ys }});
+    let nt = from_cryptol {{ `n : [32] }};
+    xs <- alloc "xs" (llvm_array n uint32_t);
+    ys <- alloc "ys" (llvm_array n uint32_t);
+    let xval = struct [ xs.p, nt ];
+    let yval = struct [ ys.p, nt ];
+    xp <- alloc_init (struct_t "vec_t") xval;
+    yp <- alloc_init (struct_t "vec_t") yval;
+    execute [xp, yp];
+    let (xst, yst) = (xs.t, ys.t);
+    returns (from_cryptol {{ dotprod xst yst }});
 };
 
 // The same spec as above, but for the case where both input pointers
 // point to the same object.
 let dotprod_aliased_spec n = do {
-    let nt = crucible_term {{ `n : [32] }};
-    (xs, xsp) <- ptr_to_fresh "xs" (llvm_array n i32);
-    let xval = crucible_struct [ xsp, nt ];
-    xp <- alloc_init (llvm_struct "struct.vec_t") xval;
-    crucible_execute_func [xp, xp];
-    crucible_return (crucible_term {{ dotprod xs xs }});
+    let nt = from_cryptol {{ `n : [32] }};
+    xs <- alloc "xs" (llvm_array n uint32_t);
+    let xval = struct [ xs.p, nt ];
+    xp <- alloc_init (struct_t "vec_t") xval;
+    execute [xp, xp];
+    let xst = xs.t;
+    returns (from_cryptol {{ dotprod xst xst }});
 };
 
 // Load the LLVM bitcode file generated from `dotprod.c`

--- a/templates/c/dotprod.saw
+++ b/templates/c/dotprod.saw
@@ -5,16 +5,17 @@ import "dotprod.cry";
 include "../../common/llvm.saw";
 
 // This function provides a new vec_t of a given size
-let vec_t (name : String) (rw : Term) (size : Int) = do {
-  elts <- alloc (str_concat name ".elts") rw (llvm_array size uint32_t);
-  let eltst = elts.t;
-  
-  let sizet = {{ `size : [32] }};
-  let sizes = from_cryptol sizet;
+let vec_t (name : String) (rw : Term) (n : Int) = do {
+  //Create the structure
+  elts <- alloc (str_concat name ".elts") rw (llvm_array n uint32_t);
+  size <- variable "size" uint32_t (CON {{ `n : [32] }});
+  vec <- struct "vec_t" rw [ elts.p, size.s ];
 
+  //Create the Term for the structure (for use in Cryptol expressions)
+  let (sizet, eltst) = (size.t, elts.t);
   let vect = {{ {size=sizet, elts=eltst} }};
 
-  vec <- struct [ elts.p, sizes ] "vec_t" rw;
+  //Return a pointer, a SetupValue, and a Term for the new vec_t.
   return {p=vec.p, s=vec.s, t=vect};
 };
 

--- a/templates/c/dotprod.saw
+++ b/templates/c/dotprod.saw
@@ -12,7 +12,7 @@ let vec_t (name : String) (rw : Term) (size : Int) = do {
   let vec_struct = struct [ elts.p, sizet ];
   pvec_struct <- pointer rw (struct_t "vec_t");
   points_to pvec_struct vec_struct;
-  return {p=pvec_struct, struct=vec_struct, size={s=size, t=sizet}, elts=elts};
+  return {p=pvec_struct, s=vec_struct, size={s=size, t=sizet}, elts=elts};
 };
 
 // This function specifies what the `dotprod` function should do when

--- a/templates/c/dotprod.saw
+++ b/templates/c/dotprod.saw
@@ -9,7 +9,7 @@ let vec_t (rw : Term) (n : Int) (name : String) = do {
   //Create the structure
   elts <- alloc rw (llvm_array n uint32_t) (str_concat name ".elts") FRESH;
   size <- variable uint32_t "size" (STALE {{ `n : [32] }});
-  vec <- struct rw "vec_t" [ elts.p, size.s ];
+  vec <- struct [ elts.p, size.s ];
 
   vecp <- pointer rw (struct_t "vec_t");
   points_to vecp vec.s;

--- a/templates/c/dotprod.saw
+++ b/templates/c/dotprod.saw
@@ -5,18 +5,21 @@ import "dotprod.cry";
 include "../../common/llvm.saw";
 
 // This function provides a new vec_t of a given size
-let vec_t (name : String) (rw : Term) (n : Int) = do {
+let vec_t (rw : Term) (n : Int) (name : String) = do {
   //Create the structure
-  elts <- alloc (str_concat name ".elts") rw (llvm_array n uint32_t);
-  size <- variable "size" uint32_t (CON {{ `n : [32] }});
-  vec <- struct "vec_t" rw [ elts.p, size.s ];
+  elts <- alloc rw (llvm_array n uint32_t) (str_concat name ".elts") FRESH;
+  size <- variable uint32_t "size" (STALE {{ `n : [32] }});
+  vec <- struct rw "vec_t" [ elts.p, size.s ];
+
+  vecp <- pointer rw (struct_t "vec_t");
+  points_to vecp vec.s;
 
   //Create the Term for the structure (for use in Cryptol expressions)
   let (sizet, eltst) = (size.t, elts.t);
   let vect = {{ {size=sizet, elts=eltst} }};
 
   //Return a pointer, a SetupValue, and a Term for the new vec_t.
-  return {p=vec.p, s=vec.s, t=vect};
+  return {p=vecp, s=vec.s, t=vect};
 };
 
 // This function specifies what the `dotprod` function should do when
@@ -24,8 +27,8 @@ let vec_t (name : String) (rw : Term) (n : Int) = do {
 
 //uint32_t dotprod(vec_t *x, vec_t *y)
 let dotprod_spec n = do {
-    x <- vec_t "x" CONST n;
-    y <- vec_t "y" CONST n;
+    x <- vec_t CONST n "x";
+    y <- vec_t CONST n "y";
 
     execute [x.p, y.p];
 
@@ -37,7 +40,7 @@ let dotprod_spec n = do {
 // point to the same object.
 //uint32_t dotprod(vec_t *x, vec_t *x)
 let dotprod_aliased_spec n = do {
-    x <- vec_t "x" CONST n;
+    x <- vec_t CONST n "x";
 
     execute [x.p, x.p];
 

--- a/templates/c/dotprod.saw
+++ b/templates/c/dotprod.saw
@@ -7,10 +7,15 @@ include "../../common/llvm.saw";
 // This function provides a new vec_t of a given size
 let vec_t (name : String) (rw : Term) (size : Int) = do {
   elts <- alloc (str_concat name ".elts") rw (llvm_array size uint32_t);
-  let sizet = from_cryptol {{ `size : [32] }};
+  let eltst = elts.t;
+  
+  let sizet = {{ `size : [32] }};
+  let sizes = from_cryptol sizet;
 
-  vec_struct <- struct [ elts.p, sizet ] "vec_t" rw;
-  return {p=vec_struct.p, s=vec_struct.s, size={s=size, t=sizet}, elts=elts};
+  let vect = {{ {size=sizet, elts=eltst} }};
+
+  vec <- struct [ elts.p, sizes ] "vec_t" rw;
+  return {p=vec.p, s=vec.s, t=vect};
 };
 
 // This function specifies what the `dotprod` function should do when
@@ -23,8 +28,8 @@ let dotprod_spec n = do {
 
     execute [x.p, y.p];
 
-    let (xst, yst) = ((x.elts).t, (y.elts).t);
-    returns (from_cryptol {{ dotprod xst yst }});
+    let (xt, yt) = (x.t, y.t);
+    returns (from_cryptol {{ dotprod xt.elts yt.elts }});
 };
 
 // The same spec as above, but for the case where both input pointers
@@ -34,8 +39,9 @@ let dotprod_aliased_spec n = do {
     x <- vec_t "x" CONST n;
 
     execute [x.p, x.p];
-    let xst = (x.elts).t;
-    returns (from_cryptol {{ dotprod xst xst }});
+
+    let xt = x.t;
+    returns (from_cryptol {{ dotprod xt.elts xt.elts }});
 };
 
 // Load the LLVM bitcode file generated from `dotprod.c`

--- a/templates/c/dotprod.saw
+++ b/templates/c/dotprod.saw
@@ -9,10 +9,8 @@ let vec_t (name : String) (rw : Term) (size : Int) = do {
   elts <- alloc (str_concat name ".elts") rw (llvm_array size uint32_t);
   let sizet = from_cryptol {{ `size : [32] }};
 
-  let vec_struct = struct [ elts.p, sizet ];
-  pvec_struct <- pointer rw (struct_t "vec_t");
-  points_to pvec_struct vec_struct;
-  return {p=pvec_struct, s=vec_struct, size={s=size, t=sizet}, elts=elts};
+  vec_struct <- struct [ elts.p, sizet ] "vec_t" rw;
+  return {p=vec_struct.p, s=vec_struct.s, size={s=size, t=sizet}, elts=elts};
 };
 
 // This function specifies what the `dotprod` function should do when

--- a/templates/c/dotprod.saw
+++ b/templates/c/dotprod.saw
@@ -4,42 +4,56 @@ import "dotprod.cry";
 // Include common LLVM utilities
 include "../../common/llvm.saw";
 
+// This function provides a new vec_t of a given size
+let vec_t (name : String) (rw : Term) (size : Int) = do {
+  elts <- alloc (str_concat name ".elts") rw (llvm_array size uint32_t);
+  let sizet = from_cryptol {{ `size : [32] }};
+
+  let vec_struct = struct [ elts.p, sizet ];
+  pvec_struct <- pointer rw (struct_t "vec_t");
+  points_to pvec_struct vec_struct;
+  return {p=pvec_struct, struct=vec_struct, size={s=size, t=sizet}, elts=elts};
+};
+
 // This function specifies what the `dotprod` function should do when
 // given an input of size `n`.
+
+//uint32_t dotprod(vec_t *x, vec_t *y)
 let dotprod_spec n = do {
-    let nt = from_cryptol {{ `n : [32] }};
-    xs <- alloc "xs" (llvm_array n uint32_t);
-    ys <- alloc "ys" (llvm_array n uint32_t);
-    let xval = struct [ xs.p, nt ];
-    let yval = struct [ ys.p, nt ];
-    xp <- alloc_init (struct_t "vec_t") xval;
-    yp <- alloc_init (struct_t "vec_t") yval;
-    execute [xp, yp];
-    let (xst, yst) = (xs.t, ys.t);
+    x <- vec_t "x" CONST n;
+    y <- vec_t "y" CONST n;
+
+    execute [x.p, y.p];
+
+    let (xst, yst) = ((x.elts).t, (y.elts).t);
     returns (from_cryptol {{ dotprod xst yst }});
 };
 
 // The same spec as above, but for the case where both input pointers
 // point to the same object.
+//uint32_t dotprod(vec_t *x, vec_t *x)
 let dotprod_aliased_spec n = do {
-    let nt = from_cryptol {{ `n : [32] }};
-    xs <- alloc "xs" (llvm_array n uint32_t);
-    let xval = struct [ xs.p, nt ];
-    xp <- alloc_init (struct_t "vec_t") xval;
-    execute [xp, xp];
-    let xst = xs.t;
+    x <- vec_t "x" CONST n;
+
+    execute [x.p, x.p];
+    let xst = (x.elts).t;
     returns (from_cryptol {{ dotprod xst xst }});
 };
 
 // Load the LLVM bitcode file generated from `dotprod.c`
 m <- llvm_load_module "dotprod.bc";
 
-let sz = 4;
+let size = 4;
 
 // Verify the distinct version
-dotprod_ov <- crucible_llvm_verify m "dotprod" [] true (dotprod_spec sz) z3;
-crucible_llvm_verify m "dotprod_wrap" [dotprod_ov] true (dotprod_spec sz) z3;
+dotprod_ov <- llvm_verify m "dotprod" [] (dotprod_spec size);
+
+// Test simply to demonstrate how overrides are applied
+llvm_verify m "dotprod" [dotprod_ov] (dotprod_spec size);
 
 // Verify the aliased version
-dotprod_aliased_ov <- crucible_llvm_verify m "dotprod" [] true (dotprod_aliased_spec sz) z3;
-crucible_llvm_verify m "dotprod_wrap" [dotprod_aliased_ov] true (dotprod_aliased_spec sz) z3;
+dotprod_aliased_ov <- llvm_verify m "dotprod" [] (dotprod_aliased_spec size);
+
+// Test simply to demonstrate how overrides are applied
+llvm_verify m "dotprod" [dotprod_aliased_ov] (dotprod_aliased_spec size);
+


### PR DESCRIPTION
For an example of this in action, see https://github.com/weaversa/bitvector/blob/saw-improvements/saw/bitvector.saw.

I think there is plenty of room for improvement. I'd like to create some demos using these new methods, so consider this a first step. Feel free to comment or contribute changes.