### PR TITLE
Add signal-protocol demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,26 @@ jobs:
       shell: bash
       run: .github/ci.sh install_system_deps
 
+    - name: "Install Python"
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+
+    - name: "Install Poetry"
+      uses: abatilo/actions-poetry@v2.0.0
+      with:
+        poetry-version: 1.1.5
+
+    - name: "Install wllvm"
+      shell: bash
+      run: pip install wllvm
+
     - name: "Run demos"
       shell: bash
       run: |
         export PATH="$PWD/bin:$PATH"
         make -C templates/c
         make -C demos/salsa20
+        make -C demos/signal-protocol
+        make -C demos/signal-protocol all-python
         make -C demos/xxhash

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,140 @@
 *.bc
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "cryptol-specs"]
 	path = cryptol-specs
 	url = https://github.com/galoisinc/cryptol-specs
+[submodule "demos/signal-protocol/libsignal-protocol-c"]
+	path = demos/signal-protocol/libsignal-protocol-c
+	url = https://github.com/signalapp/libsignal-protocol-c

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ directories:
 To run these examples, you'll first need to install SAW. More
 information on doing so is available on the [main web site for
 SAW](https://saw.galois.com). More information is also available in the
-[GitHub repository](https://github.com/GaloisInc/saw-script). SAW 0.6 or
+[GitHub repository](https://github.com/GaloisInc/saw-script). SAW 0.8 or
 later is required to run the examples in this repo.
 
 SAW requires the Z3 SMT solver, and supports the use of other SMT
@@ -37,9 +37,18 @@ unfortunately do not include a `.jar` file containing the standard
 libraries, and SAW does not have the ability to read the pre-compiled
 versions of the standard libraries that they do include.
 
+In addition to the requirements above, the `signal-protocol` demo requires
+some additional dependencies to run. For more information, view the
+demo's [associated `README.md` file](demos/signal-protocol/README.md).
+
 Each of the verification demos includes a `Makefile` that will perform
 whatever steps are required to compile the source code under analysis
-and the execute `saw` on the appropriate verification script.
+and the execute `saw` on the appropriate verification script. Each
+`Makefile` can be invoked by running `make` in the appropriate directory,
+or alternatively, running `make -C demos/<demo-name>` from the top-level
+directory. The `signal-protocol` demo, in addition to featuring a
+SAWScript-based demo, also includes a Python-based demo that can be run
+with `make all-python`.
 
 Some of the demos reference Cryptol specifications from the
 `cryptol-specs` repository, which is a submodule to this repository. To

--- a/demos/signal-protocol/Makefile
+++ b/demos/signal-protocol/Makefile
@@ -1,0 +1,38 @@
+LIBSIGNAL_DIR=libsignal-protocol-c
+LIBSIGNAL_BUILD_DIR=$(LIBSIGNAL_DIR)/build
+LLVM_LINK_NAME=$(shell dirname $(shell readlink -f $(shell which clang)))/llvm-link
+
+.PHONY: all
+all: all-saw-script
+
+.PHONY: all-saw-script
+all-saw-script: libsignal
+	saw saw/main.saw
+
+.PHONY: all-python
+all-python: libsignal
+	poetry install
+	poetry run mypy python/main.py
+	poetry run python python/main.py
+
+libsignal: c/libsignal-everything.bc
+
+$(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a:
+	mkdir -p $(LIBSIGNAL_BUILD_DIR)
+	(cd $(LIBSIGNAL_BUILD_DIR) && \
+	LLVM_COMPILER=clang cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=wllvm .. && \
+	LLVM_COMPILER=clang make)
+
+$(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a.bc: $(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a
+	(cd $(LIBSIGNAL_BUILD_DIR) && \
+	extract-bc -l $(LLVM_LINK_NAME) -b src/libsignal-protocol-c.a)
+
+c/libsignal-everything.bc: $(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a.bc c/dummy_signal_crypto_provider.bc
+	$(LLVM_LINK_NAME) $^ -o $@
+
+c/dummy_signal_crypto_provider.bc: c/dummy_signal_crypto_provider.c
+	clang -g -c -emit-llvm $< -o $@ -I$(LIBSIGNAL_DIR)/src
+
+.PHONY: clean
+clean:
+	rm -rf $(LIBSIGNAL_BUILD_DIR) c/dummy_signal_crypto_provider.bc

--- a/demos/signal-protocol/README.md
+++ b/demos/signal-protocol/README.md
@@ -1,0 +1,40 @@
+# `signal-protocol`
+
+This demonstrates specifications for certain functions from
+[`libsignal-protocol-c`](https://github.com/signalapp/libsignal-protocol-c),
+a C implementation of the [Signal Protocol](https://en.wikipedia.org/wiki/Signal_Protocol).
+This includes both a SAWScript implementation (under the `saw/` directory) as well as a
+Python implementation (under the `python/` directory).
+
+The Python code in particular is described in more detail in
+[this blog post](TODO RGS: Update when blog is published).
+
+# Dependencies
+
+In addition to the dependencies mentioned in the [top-level `README`](../../README.md),
+the following additional dependencies are required, regardless of whether you are
+running the SAWScript or Python demo:
+
+* [CMake](https://cmake.org/)
+* [WLLVM](https://github.com/travitch/whole-program-llvm)
+
+If you are running the Python demo, you will also need:
+
+* [Python](https://www.python.org/) (3.8 or later)
+* [Poetry](https://python-poetry.org/)
+
+# SAWScript version
+
+To run the SAWScript demo, run:
+
+```
+$ make
+```
+
+# Python version
+
+To run the Python demo, run:
+
+```
+$ make all-python
+```

--- a/demos/signal-protocol/c/.gitignore
+++ b/demos/signal-protocol/c/.gitignore
@@ -1,0 +1,54 @@
+*.bc
+
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf

--- a/demos/signal-protocol/c/dummy_signal_crypto_provider.c
+++ b/demos/signal-protocol/c/dummy_signal_crypto_provider.c
@@ -1,0 +1,86 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "signal_protocol_internal.h"
+
+// Definition taken from
+// https://github.com/signalapp/libsignal-protocol-c/blob/3a83a4f4ed2302ff6e68ab569c88793b50c22d28/src/protocol.c#L10
+#define SIGNAL_MESSAGE_MAC_LENGTH 8
+
+// Type signatures taken from
+// https://github.com/signalapp/libsignal-protocol-c/blob/3a83a4f4ed2302ff6e68ab569c88793b50c22d28/src/signal_protocol.h#L276
+int dummy_random_func(uint8_t *data, size_t len, void *user_data) {
+    return 0;
+}
+
+int dummy_hmac_sha256_init_func(void **hmac_context, const uint8_t *key, size_t key_len, void *user_data) {
+    uint8_t *dummy_hmac_context = malloc(sizeof(uint8_t));
+    if (dummy_hmac_context == NULL) {
+        return -1;
+    }
+    *dummy_hmac_context = 42;
+    *hmac_context = dummy_hmac_context;
+    return 0;
+}
+
+int dummy_hmac_sha256_update_func(void *hmac_context, const uint8_t *data, size_t data_len, void *user_data) {
+    return 0;
+}
+
+int dummy_hmac_sha256_final_func(void *hmac_context, signal_buffer **output, void *user_data) {
+    *output = signal_buffer_alloc(SIGNAL_MESSAGE_MAC_LENGTH);
+    if (*output == NULL) {
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
+void dummy_hmac_sha256_cleanup_func(void *hmac_context, void *user_data) {
+    free(hmac_context);
+}
+
+int dummy_sha512_digest_init_func(void **digest_context, void *user_data) {
+    uint8_t *dummy_digest_context = malloc(sizeof(uint8_t));
+    if (dummy_digest_context == NULL) {
+        return -1;
+    }
+    *dummy_digest_context = 42;
+    *digest_context = digest_context;
+    return 0;
+}
+
+int dummy_sha512_digest_update_func(void *digest_context, const uint8_t *data, size_t data_len, void *user_data) {
+    return 0;
+}
+
+int dummy_sha512_digest_final_func(void *digest_context, signal_buffer **output, void *user_data) {
+    *output = signal_buffer_alloc(SIGNAL_MESSAGE_MAC_LENGTH);
+    if (*output == NULL) {
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
+void dummy_sha512_digest_cleanup_func(void *digest_context, void *user_data) {
+    free(digest_context);
+}
+
+int dummy_encrypt_func(signal_buffer **output,
+        int cipher,
+        const uint8_t *key, size_t key_len,
+        const uint8_t *iv, size_t iv_len,
+        const uint8_t *plaintext, size_t plaintext_len,
+        void *user_data) {
+    return 0;
+}
+
+int dummy_decrypt_func(signal_buffer **output,
+        int cipher,
+        const uint8_t *key, size_t key_len,
+        const uint8_t *iv, size_t iv_len,
+        const uint8_t *ciphertext, size_t ciphertext_len,
+        void *user_data) {
+    return 0;
+}

--- a/demos/signal-protocol/cryptol/HMAC.cry
+++ b/demos/signal-protocol/cryptol/HMAC.cry
@@ -1,0 +1,16 @@
+type HMAC_CONTEXT_LENGTH = 1
+type HMACContext = [HMAC_CONTEXT_LENGTH][8]
+
+type SIGNAL_MESSAGE_MAC_LENGTH = 8
+
+hmac_init : {n} [n][8] -> // Key
+            HMACContext
+hmac_init = undefined
+
+hmac_update : {n} [n][8] -> // Data
+              HMACContext -> HMACContext
+hmac_update = undefined
+
+hmac_final : HMACContext ->
+             [SIGNAL_MESSAGE_MAC_LENGTH][8] // Signal buffer
+hmac_final = undefined

--- a/demos/signal-protocol/poetry.lock
+++ b/demos/signal-protocol/poetry.lock
@@ -1,0 +1,265 @@
+[[package]]
+name = "argo-client"
+version = "0.0.4"
+description = "A JSON RPC client library."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+mypy = "*"
+requests = "*"
+
+[[package]]
+name = "bitvector"
+version = "3.4.9"
+description = "A memory-efficient packed representation for bit arrays in pure Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "certifi"
+version = "2020.12.5"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "chardet"
+version = "4.0.0"
+description = "Universal encoding detector for Python 2 and 3"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "cryptol"
+version = "2.11.0"
+description = "Cryptol client for the Cryptol 2.11 RPC server"
+category = "main"
+optional = false
+python-versions = ">=3.8,<4.0"
+
+[package.dependencies]
+argo-client = "0.0.4"
+BitVector = ">=3.4.9,<4.0.0"
+requests = ">=2.25.1,<3.0.0"
+
+[[package]]
+name = "idna"
+version = "2.10"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "isort"
+version = "5.8.0"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.6,<4.0"
+
+[package.extras]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pipreqs", "pip-api"]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+
+[[package]]
+name = "mypy"
+version = "0.812"
+description = "Optional static typing for Python"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3,<0.5.0"
+typed-ast = ">=1.4.0,<1.5.0"
+typing-extensions = ">=3.7.4"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "requests"
+version = "2.25.1"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = ">=3.0.2,<5"
+idna = ">=2.5,<3"
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+
+[[package]]
+name = "saw-client"
+version = "0.8.1"
+description = "SAW client for the SAW 0.8 RPC server"
+category = "main"
+optional = false
+python-versions = ">=3.8,<4.0"
+
+[package.dependencies]
+argo-client = "0.0.4"
+BitVector = ">=3.4.9,<4.0.0"
+cryptol = "2.11.0"
+requests = ">=2.25.1,<3.0.0"
+
+[[package]]
+name = "typed-ast"
+version = "1.4.3"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "typing-extensions"
+version = "3.7.4.3"
+description = "Backported and Experimental Type Hints for Python 3.5+"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "urllib3"
+version = "1.26.4"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+brotli = ["brotlipy (>=0.6.0)"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.8"
+content-hash = "37b0542b2975ab9dce888e3cf8efcc2a5bf54d0b25af66bccbb61704d5298df1"
+
+[metadata.files]
+argo-client = [
+    {file = "argo-client-0.0.4.tar.gz", hash = "sha256:1ce6af1cbc738d08348dcb62d573968da58e2382cb4ea753cc061aa16d45ff6a"},
+    {file = "argo_client-0.0.4-py2-none-any.whl", hash = "sha256:74c13e9f3bf5a48eeda847af343bdaf54a950c100496ed3c342a51f5406cf568"},
+]
+bitvector = [
+    {file = "BitVector-3.4.9.tar.gz", hash = "sha256:a5e94cbb4804213b1f0c32d84517cd8f0bb8c689b5eb8055d351632e220a5edd"},
+]
+certifi = [
+    {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
+    {file = "certifi-2020.12.5.tar.gz", hash = "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c"},
+]
+chardet = [
+    {file = "chardet-4.0.0-py2.py3-none-any.whl", hash = "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"},
+    {file = "chardet-4.0.0.tar.gz", hash = "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"},
+]
+cryptol = [
+    {file = "cryptol-2.11.0-py3-none-any.whl", hash = "sha256:60c16ddef674bd7f9bf27b4962c72a696ff10c8ded5d18ba9f73b797897e3494"},
+    {file = "cryptol-2.11.0.tar.gz", hash = "sha256:e252f95cea05268c895ae779701947fea34d43f2715dd3444692a35663b029f3"},
+]
+idna = [
+    {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
+    {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
+]
+isort = [
+    {file = "isort-5.8.0-py3-none-any.whl", hash = "sha256:2bb1680aad211e3c9944dbce1d4ba09a989f04e238296c87fe2139faa26d655d"},
+    {file = "isort-5.8.0.tar.gz", hash = "sha256:0a943902919f65c5684ac4e0154b1ad4fac6dcaa5d9f3426b732f1c8b5419be6"},
+]
+mypy = [
+    {file = "mypy-0.812-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a26f8ec704e5a7423c8824d425086705e381b4f1dfdef6e3a1edab7ba174ec49"},
+    {file = "mypy-0.812-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:28fb5479c494b1bab244620685e2eb3c3f988d71fd5d64cc753195e8ed53df7c"},
+    {file = "mypy-0.812-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:9743c91088d396c1a5a3c9978354b61b0382b4e3c440ce83cf77994a43e8c521"},
+    {file = "mypy-0.812-cp35-cp35m-win_amd64.whl", hash = "sha256:d7da2e1d5f558c37d6e8c1246f1aec1e7349e4913d8fb3cb289a35de573fe2eb"},
+    {file = "mypy-0.812-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4eec37370483331d13514c3f55f446fc5248d6373e7029a29ecb7b7494851e7a"},
+    {file = "mypy-0.812-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d65cc1df038ef55a99e617431f0553cd77763869eebdf9042403e16089fe746c"},
+    {file = "mypy-0.812-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:61a3d5b97955422964be6b3baf05ff2ce7f26f52c85dd88db11d5e03e146a3a6"},
+    {file = "mypy-0.812-cp36-cp36m-win_amd64.whl", hash = "sha256:25adde9b862f8f9aac9d2d11971f226bd4c8fbaa89fb76bdadb267ef22d10064"},
+    {file = "mypy-0.812-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:552a815579aa1e995f39fd05dde6cd378e191b063f031f2acfe73ce9fb7f9e56"},
+    {file = "mypy-0.812-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:499c798053cdebcaa916eef8cd733e5584b5909f789de856b482cd7d069bdad8"},
+    {file = "mypy-0.812-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:5873888fff1c7cf5b71efbe80e0e73153fe9212fafdf8e44adfe4c20ec9f82d7"},
+    {file = "mypy-0.812-cp37-cp37m-win_amd64.whl", hash = "sha256:9f94aac67a2045ec719ffe6111df543bac7874cee01f41928f6969756e030564"},
+    {file = "mypy-0.812-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d23e0ea196702d918b60c8288561e722bf437d82cb7ef2edcd98cfa38905d506"},
+    {file = "mypy-0.812-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:674e822aa665b9fd75130c6c5f5ed9564a38c6cea6a6432ce47eafb68ee578c5"},
+    {file = "mypy-0.812-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:abf7e0c3cf117c44d9285cc6128856106183938c68fd4944763003decdcfeb66"},
+    {file = "mypy-0.812-cp38-cp38-win_amd64.whl", hash = "sha256:0d0a87c0e7e3a9becdfbe936c981d32e5ee0ccda3e0f07e1ef2c3d1a817cf73e"},
+    {file = "mypy-0.812-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7ce3175801d0ae5fdfa79b4f0cfed08807af4d075b402b7e294e6aa72af9aa2a"},
+    {file = "mypy-0.812-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b09669bcda124e83708f34a94606e01b614fa71931d356c1f1a5297ba11f110a"},
+    {file = "mypy-0.812-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:33f159443db0829d16f0a8d83d94df3109bb6dd801975fe86bacb9bf71628e97"},
+    {file = "mypy-0.812-cp39-cp39-win_amd64.whl", hash = "sha256:3f2aca7f68580dc2508289c729bd49ee929a436208d2b2b6aab15745a70a57df"},
+    {file = "mypy-0.812-py3-none-any.whl", hash = "sha256:2f9b3407c58347a452fc0736861593e105139b905cca7d097e413453a1d650b4"},
+    {file = "mypy-0.812.tar.gz", hash = "sha256:cd07039aa5df222037005b08fbbfd69b3ab0b0bd7a07d7906de75ae52c4e3119"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+requests = [
+    {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},
+    {file = "requests-2.25.1.tar.gz", hash = "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"},
+]
+saw-client = [
+    {file = "saw-client-0.8.1.tar.gz", hash = "sha256:6597526e516b46f4aec10b8f3dd5637745fcfec867863bdb95ba09d059aeec94"},
+    {file = "saw_client-0.8.1-py3-none-any.whl", hash = "sha256:4b2c6a19493f8322461f19936483ee84de08f34149c296f6c9f8a678720ed47e"},
+]
+typed-ast = [
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-win32.whl", hash = "sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-win_amd64.whl", hash = "sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-win32.whl", hash = "sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-win_amd64.whl", hash = "sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-win32.whl", hash = "sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805"},
+    {file = "typed_ast-1.4.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39"},
+    {file = "typed_ast-1.4.3-cp38-cp38-win32.whl", hash = "sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927"},
+    {file = "typed_ast-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40"},
+    {file = "typed_ast-1.4.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3"},
+    {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
+    {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
+    {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
+]
+typing-extensions = [
+    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
+    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
+    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.4-py2.py3-none-any.whl", hash = "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df"},
+    {file = "urllib3-1.26.4.tar.gz", hash = "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"},
+]

--- a/demos/signal-protocol/pyproject.toml
+++ b/demos/signal-protocol/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "signal-protocol"
+version = "0.1.0"
+description = ""
+authors = ["Ryan Scott <rscott@galois.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+requests = "^2.25.1"
+BitVector = "^3.4.9"
+saw-client = "^0.8.1"
+
+[tool.poetry.dev-dependencies]
+mypy = "^0.812"
+isort = "^5.7.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/demos/signal-protocol/python/buffer_helpers.py
+++ b/demos/signal-protocol/python/buffer_helpers.py
@@ -1,0 +1,29 @@
+from saw_client.llvm import Contract, LLVMType, SetupVal, array_ty, cryptol, i8, struct
+
+def int_to_8_cryptol(length: int):
+    return cryptol("`{i}:[8]".format(i=length))
+
+def int_to_32_cryptol(length: int):
+    return cryptol("`{i}:[32]".format(i=length))
+
+def int_to_64_cryptol(length: int):
+    return cryptol("`{i}:[64]".format(i=length))
+
+def buffer_type(length: int) -> LLVMType:
+    return array_ty(8 + length, i8)
+
+def alloc_buffer_aligned(spec: Contract, length: int) -> SetupVal:
+    return spec.alloc(buffer_type(length), alignment = 16)
+
+def alloc_buffer_aligned_readonly(spec: Contract, length: int) -> SetupVal:
+    return spec.alloc(buffer_type(length), alignment = 16, read_only = True)
+
+def alloc_pointsto_buffer(spec: Contract, length: int, data: SetupVal) -> SetupVal:
+    buf = alloc_buffer_aligned(spec, length)
+    spec.points_to(buf, struct(int_to_64_cryptol(length), data), check_target_type = None)
+    return buf
+
+def alloc_pointsto_buffer_readonly(spec: Contract, length: int, data: SetupVal) -> SetupVal:
+    buf = alloc_buffer_aligned_readonly(spec, length)
+    spec.points_to(buf, struct(int_to_64_cryptol(length), data), check_target_type = None)
+    return buf

--- a/demos/signal-protocol/python/curve.py
+++ b/demos/signal-protocol/python/curve.py
@@ -1,0 +1,33 @@
+from saw_client import llvm_verify
+from saw_client.llvm import Contract, FreshVar, alias_ty, array_ty, i8, ptr_ty, struct_ty
+
+from buffer_helpers import *
+from load import mod
+from saw_helpers import *
+
+DJB_TYPE = 0x05
+DJB_KEY_LEN = 32
+
+def alloc_ec_public_key(spec: Contract) -> Tuple[FreshVar, FreshVar, SetupVal]:
+    signal_type_base_ty = alias_ty("struct.signal_type_base")
+    djb_array_ty = array_ty(DJB_KEY_LEN, i8)
+    key_base = spec.fresh_var(signal_type_base_ty, "key_base")
+    key_data = spec.fresh_var(djb_array_ty, "key_data")
+    key = spec.alloc(struct_ty(signal_type_base_ty, djb_array_ty),
+                     points_to = struct(key_base, key_data))
+    return (key_base, key_data, key)
+
+class ECPublicKeySerializeSpec(Contract):
+    def specification(self) -> None:
+        length = DJB_KEY_LEN + 1
+        buffer_ = self.alloc(ptr_ty(buffer_type(length)))
+        (_, key_data, key) = alloc_ec_public_key(self)
+
+        self.execute_func(buffer_, key)
+
+        buf = alloc_pointsto_buffer(self, length,
+                                    cryptol(f"[`({DJB_TYPE})] # {key_data.name()} : [{length}][8]"))
+        self.points_to(buffer_, buf)
+        self.returns(int_to_32_cryptol(0))
+
+ec_public_key_serialize_ov = llvm_verify(mod, "ec_public_key_serialize", ECPublicKeySerializeSpec())

--- a/demos/signal-protocol/python/load.py
+++ b/demos/signal-protocol/python/load.py
@@ -1,0 +1,14 @@
+import os
+import os.path
+
+from saw_client import LogResults, connect, llvm_load_module, view
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+
+connect()
+view(LogResults())
+
+path = [os.path.dirname(dir_path), "c", "libsignal-everything.bc"]
+bcname = os.path.join(*path)
+print(bcname)
+mod = llvm_load_module(bcname)

--- a/demos/signal-protocol/python/main.py
+++ b/demos/signal-protocol/python/main.py
@@ -1,0 +1,3 @@
+import curve
+import protocol
+import signal_protocol

--- a/demos/signal-protocol/python/protocol.py
+++ b/demos/signal-protocol/python/protocol.py
@@ -1,0 +1,212 @@
+import os
+import os.path
+
+from saw_client import cryptol_load_file, llvm_assume, llvm_verify
+from saw_client.llvm import Contract, alias_ty, array, array_ty, cryptol, elem, field, global_var, i8, i32, i64, null, ptr_ty, struct, void
+from saw_client.proofscript import ProofScript, z3
+
+from buffer_helpers import *
+from curve import *
+from load import *
+from saw_helpers import *
+
+
+cryptol_load_file("cryptol/HMAC.cry")
+
+signal_context_ty = alias_ty("struct.signal_context")
+
+message_version = 3
+
+HMAC_CONTEXT_LENGTH = 1
+RATCHET_MAC_KEY_LENGTH = 32
+SERIALIZED_LENGTH = 42
+SIGNAL_MESSAGE_MAC_LENGTH = 8
+
+dummy_signal_crypto_provider = struct( global_var("dummy_random_func")
+                                     , global_var("dummy_hmac_sha256_init_func")
+                                     , global_var("dummy_hmac_sha256_update_func")
+                                     , global_var("dummy_hmac_sha256_final_func")
+                                     , global_var("dummy_hmac_sha256_cleanup_func")
+                                     , global_var("dummy_sha512_digest_init_func")
+                                     , global_var("dummy_sha512_digest_update_func")
+                                     , global_var("dummy_sha512_digest_final_func")
+                                     , global_var("dummy_sha512_digest_cleanup_func")
+                                     , global_var("dummy_encrypt_func")
+                                     , global_var("dummy_decrypt_func")
+                                     , null()
+                                     )
+
+class SignalHmacSha256InitSpec(Contract):
+    key_len: int
+
+    def __init__(self, key_len: int):
+        super().__init__()
+        self.key_len = key_len
+
+    def specification(self) -> None:
+        context          = self.alloc(signal_context_ty, read_only=True)
+        hmac_context_ptr = self.alloc(ptr_ty(array_ty(HMAC_CONTEXT_LENGTH, i8)))
+        (key_data, key)  = ptr_to_fresh(self, array_ty(self.key_len, i8), "key_data")
+        self.points_to(context["crypto_provider"], dummy_signal_crypto_provider)
+
+        self.execute_func(context, hmac_context_ptr, key, int_to_64_cryptol(self.key_len))
+
+        # dummy_hmac_context = self.alloc(array_ty(HMAC_CONTEXT_LENGTH, i8),
+        #                                 points_to = array(int_to_8_cryptol(42)))
+        # self.points_to(hmac_context_ptr, dummy_hmac_context)
+        dummy_hmac_context = self.alloc(array_ty(HMAC_CONTEXT_LENGTH, i8),
+                                        points_to = cryptol(f"hmac_init`{{ {self.key_len} }} {key_data.name()}"))
+        self.points_to(hmac_context_ptr, dummy_hmac_context)
+        self.returns(int_to_32_cryptol(0))
+
+class SignalHmacSha256UpdateSpec(Contract):
+    data_len: int
+
+    def __init__(self, data_len: int):
+        super().__init__()
+        self.data_len = data_len
+
+    def specification(self) -> None:
+        context                           = self.alloc(signal_context_ty, read_only=True)
+        (hmac_context_data, hmac_context) = ptr_to_fresh(self, array_ty(HMAC_CONTEXT_LENGTH, i8), "hmac_context_data")
+        (data_data, data)                 = ptr_to_fresh(self, array_ty(self.data_len, i8), "data_data")
+        self.points_to(context["crypto_provider"], dummy_signal_crypto_provider)
+
+        self.execute_func(context, hmac_context, data, int_to_64_cryptol(self.data_len))
+
+        # self.points_to(hmac_context, hmac_context_data)
+        self.points_to(hmac_context,
+                       cryptol(f"hmac_update`{{ {self.data_len} }} {data_data.name()} {hmac_context_data.name()}"))
+        self.returns(int_to_32_cryptol(0))
+
+class SignalHmacSha256FinalSpec(Contract):
+    def specification(self) -> None:
+        context                           = self.alloc(signal_context_ty, read_only=True)
+        (hmac_context_data, hmac_context) = ptr_to_fresh(self, array_ty(HMAC_CONTEXT_LENGTH, i8), "hmac_context_data")
+        output                            = self.alloc(ptr_ty(buffer_type(SIGNAL_MESSAGE_MAC_LENGTH)))
+        self.points_to(context["crypto_provider"], dummy_signal_crypto_provider)
+
+        self.execute_func(context, hmac_context, output)
+
+        # output_buffer = alloc_buffer_aligned(self, SIGNAL_MESSAGE_MAC_LENGTH)
+        # self.points_to(output_buffer[0], int_to_64_cryptol(SIGNAL_MESSAGE_MAC_LENGTH), check_target_type = i64)
+        output_buffer = alloc_pointsto_buffer(self, SIGNAL_MESSAGE_MAC_LENGTH,
+                                              cryptol(f"hmac_final {hmac_context_data.name()}"))
+
+        self.points_to(output, output_buffer)
+        self.returns(int_to_32_cryptol(0))
+
+class SignalHmacSha256CleanupSpec(Contract):
+    def specification(self) -> None:
+        context      = self.alloc(signal_context_ty, read_only=True)
+        hmac_context = self.alloc(i8)
+        self.points_to(context["crypto_provider"], dummy_signal_crypto_provider)
+
+        self.execute_func(context, hmac_context)
+
+        self.returns(void)
+
+def mk_hmac(serialized_len: int, serialized_data: FreshVar, receiver_identity_key_data : FreshVar,
+            sender_identity_key_data: FreshVar, mac_key_len: int, mac_key_data: FreshVar) -> SetupVal:
+    sender_identity_buf   = f"[{DJB_TYPE}] # {sender_identity_key_data.name()}   : [{DJB_KEY_LEN} + 1][8]"
+    receiver_identity_buf = f"[{DJB_TYPE}] # {receiver_identity_key_data.name()} : [{DJB_KEY_LEN} + 1][8]"
+    return cryptol(f""" hmac_final
+                         (hmac_update`{{ {serialized_len} }} {serialized_data.name()}
+                          (hmac_update`{{ {DJB_KEY_LEN}+1 }} ({receiver_identity_buf})
+                           (hmac_update`{{ {DJB_KEY_LEN}+1 }} ({sender_identity_buf})
+                            (hmac_init`{{ {mac_key_len} }} {mac_key_data.name()})))) """)
+
+class SignalMessageGetMacSpec(Contract):
+    mac_key_len: int
+    serialized_len: int
+
+    def __init__(self, mac_key_len: int, serialized_len: int):
+        super().__init__()
+        self.mac_key_len = mac_key_len
+        self.serialized_len = serialized_len
+
+    def specification(self) -> None:
+        ec_public_key = alias_ty("struct.ec_public_key")
+        buffer_                                                = self.alloc(ptr_ty(buffer_type(SIGNAL_MESSAGE_MAC_LENGTH)))
+        (_, sender_identity_key_data, sender_identity_key)     = alloc_ec_public_key(self)
+        (_, receiver_identity_key_data, receiver_identity_key) = alloc_ec_public_key(self)
+        (mac_key_data, mac_key)                                = ptr_to_fresh(self, array_ty(self.mac_key_len, i8), "mac_key_data")
+        (serialized_data, serialized)                          = ptr_to_fresh(self, array_ty(self.serialized_len, i8), "serialized_data")
+        global_context                                         = self.alloc(signal_context_ty, read_only=True)
+        self.points_to(global_context["crypto_provider"], dummy_signal_crypto_provider)
+
+        self.execute_func(buffer_,
+                          int_to_8_cryptol(message_version),
+                          sender_identity_key,
+                          receiver_identity_key,
+                          mac_key, int_to_64_cryptol(self.mac_key_len),
+                          serialized, int_to_64_cryptol(self.serialized_len),
+                          global_context)
+
+        expected = mk_hmac(self.serialized_len, serialized_data, receiver_identity_key_data,
+                           sender_identity_key_data, self.mac_key_len, mac_key_data)
+
+        # buffer_buf = alloc_buffer_aligned(self, SIGNAL_MESSAGE_MAC_LENGTH)
+        # self.points_to(buffer_buf[0], int_to_64_cryptol(SIGNAL_MESSAGE_MAC_LENGTH), check_target_type = i64)
+        buffer_buf = alloc_pointsto_buffer(self, SIGNAL_MESSAGE_MAC_LENGTH, expected)
+        self.points_to(buffer_, buffer_buf)
+        self.returns(int_to_32_cryptol(0))
+
+class SignalMessageVerifyMacSpec(Contract):
+    mac_key_len: int
+    serialized_len: int
+
+    def __init__(self, mac_key_len: int, serialized_len: int):
+        super().__init__()
+        self.mac_key_len = mac_key_len
+        self.serialized_len = serialized_len
+
+    def specification(self) -> None:
+        message                                                = self.alloc(alias_ty("struct.signal_message"))
+        (_, sender_identity_key_data, sender_identity_key)     = alloc_ec_public_key(self)
+        (_, receiver_identity_key_data, receiver_identity_key) = alloc_ec_public_key(self)
+        (mac_key_data, mac_key)                                = ptr_to_fresh(self, array_ty(self.mac_key_len, i8), "mac_key_data")
+        global_context_unused_as_far_as_i_can_tell             = self.alloc(signal_context_ty, read_only=True)
+
+        base           = self.fresh_var(alias_ty("struct.signal_type_base"), "base")
+        message_type   = self.fresh_var(i32, "message_type")
+        global_context = self.alloc(signal_context_ty, read_only=True)
+        self.points_to(global_context["crypto_provider"], dummy_signal_crypto_provider)
+
+        serialized_message_len  = self.serialized_len - SIGNAL_MESSAGE_MAC_LENGTH
+        serialized_message_data = self.fresh_var(array_ty(serialized_message_len, i8), "serialized_message_data")
+
+        expected_mac_data = mk_hmac(serialized_message_len, serialized_message_data, receiver_identity_key_data,
+                                    sender_identity_key_data, self.mac_key_len, mac_key_data)
+
+        serialized = alloc_buffer_aligned(self, self.serialized_len)
+        self.points_to(serialized[0],                          int_to_64_cryptol(self.serialized_len), check_target_type = None)
+        self.points_to(serialized[8],                          serialized_message_data,                check_target_type = None)
+        self.points_to(serialized[8 + serialized_message_len], expected_mac_data,                      check_target_type = None)
+
+        base_message = struct(base, message_type, global_context, serialized)
+        self.points_to(message["base_message"],    base_message)
+        self.points_to(message["message_version"], int_to_8_cryptol(message_version))
+
+        self.execute_func(message,
+                          sender_identity_key,
+                          receiver_identity_key,
+                          mac_key, int_to_64_cryptol(self.mac_key_len),
+                          global_context_unused_as_far_as_i_can_tell)
+
+        self.returns(int_to_32_cryptol(1))
+
+uninterps = ["hmac_init", "hmac_update", "hmac_final"]
+
+signal_hmac_sha256_init_ov              = llvm_assume(mod, "signal_hmac_sha256_init",    SignalHmacSha256InitSpec(RATCHET_MAC_KEY_LENGTH))
+signal_hmac_sha256_update_djb_key_ov    = llvm_assume(mod, "signal_hmac_sha256_update",  SignalHmacSha256UpdateSpec(DJB_KEY_LEN+1))
+signal_hmac_sha256_update_serialized_ov = llvm_assume(mod, "signal_hmac_sha256_update",  SignalHmacSha256UpdateSpec(SERIALIZED_LENGTH))
+signal_hmac_sha256_final_ov             = llvm_assume(mod, "signal_hmac_sha256_final",   SignalHmacSha256FinalSpec())
+signal_hmac_sha256_cleanup_ov           = llvm_verify(mod, "signal_hmac_sha256_cleanup", SignalHmacSha256CleanupSpec())
+signal_message_get_mac_ov               = llvm_verify(mod, "signal_message_get_mac",     SignalMessageGetMacSpec(RATCHET_MAC_KEY_LENGTH, SERIALIZED_LENGTH),
+                                                      lemmas=[ signal_hmac_sha256_init_ov, signal_hmac_sha256_update_djb_key_ov,
+                                                               signal_hmac_sha256_update_serialized_ov, signal_hmac_sha256_final_ov ],
+                                                      script=ProofScript([z3(uninterps)]))
+signal_message_verify_mac_ov            = llvm_verify(mod, "signal_message_verify_mac",  SignalMessageVerifyMacSpec(RATCHET_MAC_KEY_LENGTH, SERIALIZED_LENGTH + SIGNAL_MESSAGE_MAC_LENGTH),
+                                                      lemmas=[signal_message_get_mac_ov],
+                                                      script=ProofScript([z3(uninterps)]))

--- a/demos/signal-protocol/python/saw_helpers.py
+++ b/demos/signal-protocol/python/saw_helpers.py
@@ -1,0 +1,13 @@
+from typing import Optional, Tuple
+
+from saw_client.llvm import Contract, FreshVar, LLVMType, SetupVal
+
+
+def ptr_to_fresh(spec : Contract, ty : LLVMType, name : Optional[str] = None) -> Tuple[FreshVar, SetupVal]:
+    """Add to``Contract`` ``spec`` an allocation of a pointer of type ``ty`` initialized to an unknown fresh value.
+
+    :returns A fresh variable bound to the pointers initial value and the newly allocated pointer. (The fresh
+             variable will be assigned ``name`` if provided/available.)"""
+    var = spec.fresh_var(ty, name)
+    ptr = spec.alloc(ty, points_to = var)
+    return (var, ptr)

--- a/demos/signal-protocol/python/signal_protocol.py
+++ b/demos/signal-protocol/python/signal_protocol.py
@@ -1,0 +1,186 @@
+import os
+import os.path
+
+from saw_client import llvm_verify
+from saw_client.llvm import Contract, alias_ty, array_ty, cryptol, elem, i8, i32, i64, field, global_var, ptr_ty, struct, struct_ty, void
+
+from buffer_helpers import *
+from load import mod
+from saw_helpers import *
+
+
+class BufferAllocSpec(Contract):
+    length: int
+
+    def __init__(self, length: int):
+        super().__init__()
+        self.length = length
+
+    def specification(self) -> None:
+        n_val = int_to_64_cryptol(self.length)
+
+        self.execute_func(n_val)
+
+        buf = alloc_buffer_aligned(self, self.length)
+        self.points_to(buf[0], n_val, check_target_type = i64)
+        self.returns(buf)
+
+class BufferCreateSpec(Contract):
+    length: int
+
+    def __init__(self, length: int):
+        super().__init__()
+        self.length = length
+
+    def specification(self) -> None:
+        (data, datap) = ptr_to_fresh(self, array_ty(self.length, i8), name = "data")
+
+        self.execute_func(datap, int_to_64_cryptol(self.length))
+
+        buf = alloc_pointsto_buffer(self, self.length, data)
+        self.returns(buf)
+
+class BufferCopySpec(Contract):
+    length: int
+
+    def __init__(self, length: int):
+        super().__init__()
+        self.length = length
+
+    def specification(self) -> None:
+        data = self.fresh_var(array_ty(self.length, i8), "data")
+        buf  = alloc_pointsto_buffer_readonly(self, self.length, data)
+
+        self.execute_func(buf)
+
+        new_buf = alloc_pointsto_buffer(self, self.length, data)
+        self.returns(new_buf)
+
+class BufferCopyNSpec(Contract):
+    length: int
+    n: int
+
+    def __init__(self, length: int, n: int):
+        super().__init__()
+        self.length = length
+        self.n = n
+
+    def specification(self) -> None:
+        data = self.fresh_var(array_ty(self.length, i8), "data")
+        buf  = alloc_pointsto_buffer_readonly(self, self.length, data)
+
+        self.execute_func(buf, int_to_64_cryptol(self.n))
+
+        new_length = min(self.length, self.n)
+
+        new_buf = alloc_pointsto_buffer(self, new_length, cryptol(f"take`{{ {new_length} }} {data.name()}"))
+        self.returns(new_buf)
+
+class BufferAppendSpec(Contract):
+    buf_length: int
+    additional_length: int
+
+    def __init__(self, buf_length: int, additional_length: int):
+        super().__init__()
+        self.buf_length = buf_length
+        self.additional_length = additional_length
+
+    def specification(self) -> None:
+        buf_data = self.fresh_var(array_ty(self.buf_length, i8), "buffer_data")
+        buf      = alloc_pointsto_buffer(self, self.buf_length, buf_data)
+
+        (additional_data, additional_datap) = ptr_to_fresh(self, array_ty(self.additional_length, i8),
+                                                           name = "additional_data")
+
+        self.execute_func(buf, additional_datap, int_to_64_cryptol(self.additional_length))
+
+        new_length = self.buf_length + self.additional_length;
+        new_buf    = alloc_pointsto_buffer(self, new_length,
+                                           cryptol(f"{buf_data.name()} # {additional_data.name()}"))
+        self.returns(new_buf)
+
+class ConstantMemcmpSpec(Contract):
+    n: int
+
+    def __init__(self, n: int):
+        super().__init__()
+        self.n = n
+
+    def specification(self) -> None:
+        (s1, s1p) = ptr_to_fresh(self, array_ty(self.n, i8), name = "s1")
+        (s2, s2p) = ptr_to_fresh(self, array_ty(self.n, i8), name = "s2")
+        nval = int_to_64_cryptol(self.n)
+
+        self.execute_func(s1p, s2p, nval)
+
+        self.returns(cryptol(f"zext`{{32}} (foldl (||) zero (zipWith (^) {s1.name()} {s2.name()}))"))
+
+class ConstantMemcmpEqualSpec(Contract):
+    n: int
+
+    def __init__(self, n: int):
+        super().__init__()
+        self.n = n
+
+    def specification(self) -> None:
+        (s1, s1p) = ptr_to_fresh(self, array_ty(self.n, i8), name = "s1")
+        (s2, s2p) = ptr_to_fresh(self, array_ty(self.n, i8), name = "s2")
+        self.precondition(cryptol(f"{s1.name()} == {s2.name()}"))
+
+        self.execute_func(s1p, s2p, int_to_64_cryptol(self.n))
+
+        self.returns(int_to_32_cryptol(0))
+
+DJB_TYPE = 0x05
+DJB_KEY_LEN = 32
+
+class ECPublicKeySerializeSpec(Contract):
+    def specification(self) -> None:
+        length = DJB_KEY_LEN + 1
+        signal_type_base_ty = alias_ty("struct.signal_type_base")
+        djb_array_ty = array_ty(DJB_KEY_LEN, i8)
+        buffer_ = self.alloc(ptr_ty(buffer_type(length)))
+        key_base = self.fresh_var(signal_type_base_ty, "key_base")
+        key_data = self.fresh_var(djb_array_ty, "key_data")
+        key = self.alloc(struct_ty(signal_type_base_ty, djb_array_ty),
+                         points_to = struct(key_base, key_data))
+
+        self.execute_func(buffer_, key)
+
+        buf = alloc_pointsto_buffer(self, length,
+                                    cryptol(f"[`({DJB_TYPE})] # {key_data.name()} : [{length}][8]"))
+        self.points_to(buffer_, buf)
+        self.returns(int_to_32_cryptol(0))
+
+class SignalTypeInitSpec(Contract):
+    def specification(self) -> None:
+        instance = self.alloc(alias_ty("struct.signal_type_base"))
+        destroy_func = global_var("signal_message_destroy")
+
+        self.execute_func(instance, destroy_func)
+
+        self.points_to(instance["ref_count"], int_to_32_cryptol(1))
+        self.points_to(instance["destroy"],   destroy_func)
+        self.returns(void)
+
+class SignalTypeRefSpec(Contract):
+    def specification(self) -> None:
+        ref_count = self.fresh_var(i32, "ref_count")
+        self.precondition(cryptol(f"{ref_count.name()} > 0"))
+        instance = self.alloc(alias_ty("struct.signal_type_base"))
+        self.points_to(instance["ref_count"], ref_count)
+
+        self.execute_func(instance)
+
+        self.points_to(instance["ref_count"], cryptol(f"{ref_count.name()} + 1"))
+        self.returns(void)
+
+buffer_alloc_ov          = llvm_verify(mod, "signal_buffer_alloc",    BufferAllocSpec(64))
+buffer_create_ov         = llvm_verify(mod, "signal_buffer_create",   BufferCreateSpec(64))
+buffer_copy_ov           = llvm_verify(mod, "signal_buffer_copy",     BufferCopySpec(63))
+buffer_copy_n_ov         = llvm_verify(mod, "signal_buffer_n_copy",   BufferCopyNSpec(64, 31))
+buffer_append_ov         = llvm_verify(mod, "signal_buffer_append",   BufferAppendSpec(63, 31))
+constant_memcmp_ov       = llvm_verify(mod, "signal_constant_memcmp", ConstantMemcmpSpec(63))
+constant_memcmp_equal_ov = llvm_verify(mod, "signal_constant_memcmp", ConstantMemcmpEqualSpec(63))
+signal_type_init_ov      = llvm_verify(mod, "signal_type_init",       SignalTypeInitSpec())
+signal_type_ref_ov       = llvm_verify(mod, "signal_type_ref",        SignalTypeRefSpec())

--- a/demos/signal-protocol/saw/buffer_helpers.saw
+++ b/demos/signal-protocol/saw/buffer_helpers.saw
@@ -1,0 +1,16 @@
+include "saw_helpers.saw";
+
+let buffer_type (len : Int) : LLVMType = (llvm_array (eval_size {| 8 + len|}) i8);
+let buffer_type_ptr (len : Int) : LLVMType = llvm_pointer (buffer_type len);
+let alloc_buffer_aligned (len : Int) = llvm_alloc_aligned 16 (buffer_type len);
+let alloc_buffer_aligned_readonly (len: Int ) = llvm_alloc_readonly_aligned 16 (buffer_type len);
+let alloc_pointsto_buffer (len : Int) (data : Term) = do {
+  buf <- alloc_buffer_aligned len;
+  llvm_points_to_untyped buf (llvm_struct_value [llvm_term {{`(len) : [64]}}, llvm_term data]);
+  return buf;
+};
+let alloc_pointsto_buffer_readonly (len : Int) (data : Term) = do {
+  buf <- alloc_buffer_aligned_readonly len;
+  llvm_points_to_untyped buf (llvm_struct_value [llvm_term {{`(len) : [64]}}, llvm_term data]);
+  return buf;
+};

--- a/demos/signal-protocol/saw/curve.saw
+++ b/demos/signal-protocol/saw/curve.saw
@@ -1,0 +1,32 @@
+include "buffer_helpers.saw";
+include "load.saw";
+include "saw_helpers.saw";
+
+let DJB_TYPE    = 0x05;
+let DJB_KEY_LEN = 32;
+
+let alloc_ec_public_key : CrucibleSetup (Term, Term, SetupValue) = do {
+  let signal_type_base_ty = llvm_alias "struct.signal_type_base";
+  let djb_array_ty = llvm_array DJB_KEY_LEN i8;
+  key_base <- llvm_fresh_var "key_base" signal_type_base_ty;
+  key_data <- llvm_fresh_var "key_data" djb_array_ty;
+  key <- alloc_init (llvm_struct_type [signal_type_base_ty, djb_array_ty])
+                    (llvm_struct_value [llvm_term key_base, llvm_term key_data]);
+
+  return (key_base, key_data, key);
+};
+
+let ec_public_key_serialize_spec = do {
+  let lenval = {{ `(DJB_KEY_LEN) + 1 : [64] }};
+  let len = eval_int lenval;
+  buffer <- llvm_alloc (buffer_type_ptr len);
+  (_, key_data, key) <- alloc_ec_public_key;
+
+  llvm_execute_func [buffer, key];
+
+  buf <- alloc_pointsto_buffer len {{ [`(DJB_TYPE)] # key_data : [len][8] }};
+  llvm_points_to buffer buf;
+  llvm_return (llvm_term {{ zero : [32] }});
+};
+
+ec_public_key_serialize_ov <- llvm_verify m "ec_public_key_serialize" [] false ec_public_key_serialize_spec abc;

--- a/demos/signal-protocol/saw/load.saw
+++ b/demos/signal-protocol/saw/load.saw
@@ -1,0 +1,1 @@
+m <- llvm_load_module "../c/libsignal-everything.bc";

--- a/demos/signal-protocol/saw/main.saw
+++ b/demos/signal-protocol/saw/main.saw
@@ -1,0 +1,3 @@
+include "curve.saw";
+include "signal_protocol.saw";
+include "protocol.saw";

--- a/demos/signal-protocol/saw/protocol.saw
+++ b/demos/signal-protocol/saw/protocol.saw
@@ -1,0 +1,181 @@
+import "../cryptol/HMAC.cry";
+
+include "buffer_helpers.saw";
+include "load.saw";
+include "saw_helpers.saw";
+include "curve.saw";
+
+let signal_context_ty = llvm_alias "struct.signal_context";
+let message_version = 3;
+let HMAC_CONTEXT_LENGTH = 1;
+let RATCHET_MAC_KEY_LENGTH = 32;
+let SERIALIZED_LENGTH = 42;
+let SIGNAL_MESSAGE_MAC_LENGTH = 8;
+
+let dummy_signal_crypto_provider = llvm_struct_value
+      [ llvm_global "dummy_random_func"
+      , llvm_global "dummy_hmac_sha256_init_func"
+      , llvm_global "dummy_hmac_sha256_update_func"
+      , llvm_global "dummy_hmac_sha256_final_func"
+      , llvm_global "dummy_hmac_sha256_cleanup_func"
+      , llvm_global "dummy_sha512_digest_init_func"
+      , llvm_global "dummy_sha512_digest_update_func"
+      , llvm_global "dummy_sha512_digest_final_func"
+      , llvm_global "dummy_sha512_digest_cleanup_func"
+      , llvm_global "dummy_encrypt_func"
+      , llvm_global "dummy_decrypt_func"
+      , llvm_null
+      ];
+
+let signal_hmac_sha256_init_spec (key_len : Int) = do {
+  context          <- llvm_alloc_readonly signal_context_ty;
+  hmac_context_ptr <- llvm_alloc (llvm_pointer (llvm_array HMAC_CONTEXT_LENGTH i8));
+  key_data         <- llvm_fresh_var "key_data" (llvm_array key_len i8);
+  key              <- alloc_init (llvm_array key_len i8) (llvm_term key_data);
+  llvm_points_to (llvm_field context "crypto_provider") dummy_signal_crypto_provider;
+
+  llvm_execute_func [context, hmac_context_ptr, key, llvm_term {{ `(key_len) : [64] }}];
+
+  // dummy_hmac_context <- alloc_init (llvm_array HMAC_CONTEXT_LENGTH i8) (llvm_array_value [llvm_term {{ 42 : [8] }}]);
+  // llvm_points_to hmac_context_ptr dummy_hmac_context;
+  dummy_hmac_context <- alloc_init (llvm_array HMAC_CONTEXT_LENGTH i8) (llvm_term {{ hmac_init`{key_len} key_data }});
+  llvm_points_to hmac_context_ptr dummy_hmac_context;
+  llvm_return (llvm_term {{ 0 : [32] }});
+};
+
+let signal_hmac_sha256_update_spec (data_len : Int) = do {
+  context           <- llvm_alloc_readonly signal_context_ty;
+  hmac_context_data <- llvm_fresh_var "hmac_context_data" (llvm_array HMAC_CONTEXT_LENGTH i8);
+  hmac_context      <- alloc_init (llvm_array HMAC_CONTEXT_LENGTH i8) (llvm_term hmac_context_data);
+  data_data         <- llvm_fresh_var "data_data" (llvm_array data_len i8);
+  data              <- alloc_init_readonly (llvm_array data_len i8) (llvm_term data_data);
+  llvm_points_to (llvm_field context "crypto_provider") dummy_signal_crypto_provider;
+
+  llvm_execute_func [context, hmac_context, data, llvm_term {{ `(data_len) : [64] }}];
+
+  // llvm_points_to hmac_context (llvm_term hmac_context_data);
+  llvm_points_to hmac_context (llvm_term {{ hmac_update`{data_len} data_data hmac_context_data }});
+  llvm_return (llvm_term {{ 0 : [32] }});
+};
+
+let signal_hmac_sha256_final_spec = do {
+  context           <- llvm_alloc_readonly signal_context_ty;
+  hmac_context_data <- llvm_fresh_var "hmac_context_data" (llvm_array HMAC_CONTEXT_LENGTH i8);
+  hmac_context      <- alloc_init (llvm_array HMAC_CONTEXT_LENGTH i8) (llvm_term hmac_context_data);
+  output            <- llvm_alloc (buffer_type_ptr SIGNAL_MESSAGE_MAC_LENGTH);
+  llvm_points_to (llvm_field context "crypto_provider") dummy_signal_crypto_provider;
+
+  llvm_execute_func [context, hmac_context, output];
+
+  // output_buffer <- alloc_buffer_aligned SIGNAL_MESSAGE_MAC_LENGTH;
+  // llvm_points_to_at_type (llvm_elem output_buffer 0) i64 (llvm_term {{ `(SIGNAL_MESSAGE_MAC_LENGTH) : [64] }});
+  output_buffer <- alloc_pointsto_buffer SIGNAL_MESSAGE_MAC_LENGTH {{ hmac_final hmac_context_data }};
+  llvm_points_to output output_buffer;
+  llvm_return (llvm_term {{ 0 : [32] }});
+};
+
+let signal_hmac_sha256_cleanup_spec = do {
+  context           <- llvm_alloc_readonly signal_context_ty;
+  hmac_context_data <- llvm_fresh_var "hmac_context_data" (llvm_array HMAC_CONTEXT_LENGTH i8);
+  hmac_context      <- alloc_init (llvm_array HMAC_CONTEXT_LENGTH i8) (llvm_term hmac_context_data);
+  llvm_points_to (llvm_field context "crypto_provider") dummy_signal_crypto_provider;
+
+  llvm_execute_func [context, hmac_context];
+};
+
+let mk_hmac (serialized_len : Int) (serialized_data : Term) (receiver_identity_key_data : Term)
+            (sender_identity_key_data : Term) (mac_key_len : Int) (mac_key_data : Term) : Term =
+  let sender_identity_buf   = {{ [`(DJB_TYPE)] # sender_identity_key_data   : [DJB_KEY_LEN + 1][8] }} in
+  let receiver_identity_buf = {{ [`(DJB_TYPE)] # receiver_identity_key_data : [DJB_KEY_LEN + 1][8] }} in
+  {{ hmac_final
+       (hmac_update`{serialized_len} serialized_data
+         (hmac_update`{DJB_KEY_LEN+1} receiver_identity_buf
+           (hmac_update`{DJB_KEY_LEN+1} sender_identity_buf
+             (hmac_init`{mac_key_len} mac_key_data)))) }};
+
+let signal_message_get_mac_spec (mac_key_len : Int) (serialized_len : Int) = do {
+  let ec_public_key_ty = llvm_alias "struct.ec_public_key";
+  buffer                                                 <- llvm_alloc (buffer_type_ptr SIGNAL_MESSAGE_MAC_LENGTH);
+  (_, sender_identity_key_data, sender_identity_key)     <- alloc_ec_public_key;
+  (_, receiver_identity_key_data, receiver_identity_key) <- alloc_ec_public_key;
+  mac_key_data                                           <- llvm_fresh_var "mac_key_data" (llvm_array mac_key_len i8);
+  mac_key                                                <- alloc_init (llvm_array mac_key_len i8) (llvm_term mac_key_data);
+  serialized_data                                        <- llvm_fresh_var "serialized_data" (llvm_array serialized_len i8);
+  serialized                                             <- alloc_init (llvm_array serialized_len i8) (llvm_term serialized_data);
+  global_context                                         <- llvm_alloc_readonly signal_context_ty;
+  llvm_points_to (llvm_field global_context "crypto_provider") dummy_signal_crypto_provider;
+
+  llvm_execute_func [buffer,
+                     llvm_term {{ `(message_version) : [8] }},
+                     sender_identity_key,
+                     receiver_identity_key,
+                     mac_key, llvm_term {{ `(mac_key_len) : [64] }},
+                     serialized, llvm_term {{ `(serialized_len) : [64] }},
+                     global_context];
+
+  let expected = mk_hmac serialized_len serialized_data receiver_identity_key_data sender_identity_key_data
+                                        mac_key_len mac_key_data;
+
+  // buffer_buf <- alloc_buffer_aligned SIGNAL_MESSAGE_MAC_LENGTH;
+  // llvm_points_to_at_type (llvm_elem buffer_buf 0) i64 (llvm_term {{ `(SIGNAL_MESSAGE_MAC_LENGTH) : [64] }});
+  buffer_buf <- alloc_pointsto_buffer SIGNAL_MESSAGE_MAC_LENGTH expected;
+  llvm_points_to buffer buffer_buf;
+
+  llvm_return (llvm_term {{ 0 : [32] }});
+};
+
+let signal_message_verify_mac_spec (mac_key_len : Int) (serialized_len : Int) = do {
+  message                                                <- llvm_alloc (llvm_alias "struct.signal_message");
+  (_, sender_identity_key_data, sender_identity_key)     <- alloc_ec_public_key;
+  (_, receiver_identity_key_data, receiver_identity_key) <- alloc_ec_public_key;
+  mac_key_data                                           <- llvm_fresh_var "mac_key_data" (llvm_array mac_key_len i8);
+  mac_key                                                <- alloc_init (llvm_array mac_key_len i8) (llvm_term mac_key_data);
+  global_context_unused_as_far_as_i_can_tell             <- llvm_alloc_readonly signal_context_ty;
+
+  base            <- llvm_fresh_var "base" (llvm_alias "struct.signal_type_base");
+  message_type    <- llvm_fresh_var "message_type" i32;
+  global_context  <- llvm_alloc_readonly signal_context_ty;
+  llvm_points_to (llvm_field global_context "crypto_provider") dummy_signal_crypto_provider;
+
+  let serialized_message_len = eval_int {{ `(serialized_len) - `(SIGNAL_MESSAGE_MAC_LENGTH) : [64] }};
+  serialized_message_data <- llvm_fresh_var "serialized_message_data" (llvm_array serialized_message_len i8);
+  let expected_mac_data = mk_hmac serialized_message_len serialized_message_data receiver_identity_key_data sender_identity_key_data
+                                  mac_key_len mac_key_data;
+
+  serialized <- alloc_buffer_aligned serialized_len;
+  llvm_points_to_untyped (llvm_elem serialized 0) (llvm_term {{`(serialized_len) : [64]}});
+  llvm_points_to_untyped (llvm_elem serialized 8) (llvm_term serialized_message_data);
+  llvm_points_to_untyped (llvm_elem serialized (eval_int {{ 8 + `(serialized_message_len) : [64] }})) (llvm_term expected_mac_data);
+
+  let base_message = llvm_struct_value [ llvm_term base
+                                       , llvm_term message_type
+                                       , global_context
+                                       , serialized
+                                       ];
+  llvm_points_to (llvm_field message "base_message") base_message;
+  llvm_points_to (llvm_field message "message_version") (llvm_term {{ `(message_version) : [8] }});
+
+  llvm_execute_func [message,
+                     sender_identity_key,
+                     receiver_identity_key,
+                     mac_key, llvm_term {{ `(mac_key_len) : [64] }},
+                     global_context_unused_as_far_as_i_can_tell];
+
+  llvm_return (llvm_term {{ 1 : [32] }});
+};
+
+let uninterps = ["hmac_init", "hmac_update", "hmac_final"];
+
+signal_hmac_sha256_init_ov              <- llvm_unsafe_assume_spec m "signal_hmac_sha256_init"   (signal_hmac_sha256_init_spec RATCHET_MAC_KEY_LENGTH);
+signal_hmac_sha256_update_djb_key_ov    <- llvm_unsafe_assume_spec m "signal_hmac_sha256_update" (signal_hmac_sha256_update_spec (eval_int {{ `(DJB_KEY_LEN) + 1 : [64] }}));
+signal_hmac_sha256_update_serialized_ov <- llvm_unsafe_assume_spec m "signal_hmac_sha256_update" (signal_hmac_sha256_update_spec SERIALIZED_LENGTH);
+signal_hmac_sha256_final_ov             <- llvm_unsafe_assume_spec m "signal_hmac_sha256_final"  signal_hmac_sha256_final_spec;
+signal_hmac_sha256_cleanup_ov           <- llvm_verify m "signal_hmac_sha256_cleanup" [] false signal_hmac_sha256_cleanup_spec abc;
+signal_message_get_mac_ov               <- llvm_verify m "signal_message_get_mac"     [
+                                                                                        signal_hmac_sha256_init_ov
+                                                                                      , signal_hmac_sha256_update_djb_key_ov
+                                                                                      , signal_hmac_sha256_update_serialized_ov
+                                                                                      , signal_hmac_sha256_final_ov
+                                                                                      ]
+                                                                                      false (signal_message_get_mac_spec RATCHET_MAC_KEY_LENGTH SERIALIZED_LENGTH) (unint_z3 uninterps);
+signal_message_verify_mac_ov            <- llvm_verify m "signal_message_verify_mac" [signal_message_get_mac_ov] false (signal_message_verify_mac_spec RATCHET_MAC_KEY_LENGTH (eval_int {{ `(SERIALIZED_LENGTH) + `(SIGNAL_MESSAGE_MAC_LENGTH) : [64] }})) (unint_z3 uninterps);

--- a/demos/signal-protocol/saw/saw_helpers.saw
+++ b/demos/signal-protocol/saw/saw_helpers.saw
@@ -1,0 +1,62 @@
+/*
+ * SAW helpers
+ */
+// Given a value `v` of type `ty`, allocates and returns a pointer to memory
+// storing `v`
+let alloc_init ty v = do {
+  p <- llvm_alloc ty;
+  llvm_points_to p v;
+  return p;
+};
+
+// Given a value `v` of type `ty`, allocates and returns a read only pointer to
+// memory storing `v`
+let alloc_init_readonly ty v = do {
+  p <- llvm_alloc_readonly ty;
+  llvm_points_to p v;
+  return p;
+};
+
+// Given a name `n` and a type `ty`, allocates a fresh variable `x` of type
+// `ty` and returns a tuple of `x` and a pointer to `x`.
+let ptr_to_fresh n ty = do {
+  x <- llvm_fresh_var n ty;
+  p <- alloc_init ty (llvm_term x);
+  return (x, p);
+};
+
+// Given a name `n` and a type `ty`, allocates a fresh variable `x` of type
+// `ty` and returns a tuple of `x` and a read only pointer to `x`.
+let ptr_to_fresh_readonly n ty = do {
+  x <- llvm_fresh_var n ty;
+  p <- alloc_init_readonly ty (llvm_term x);
+  return (x, p);
+};
+
+// Given a name `n` and a value `v`, assert that the `n` has a value of `v`
+let global_points_to n v = do {
+  llvm_points_to (llvm_global n) (llvm_term v);
+};
+
+// Given a name `n` and a value `v`, declare that n is initialized, and assert that has value v
+let global_alloc_init n v = do {
+  llvm_alloc_global n;
+  global_points_to n v;
+};
+
+// llvm integer type aliases
+let i8 = llvm_int 8;
+let i16 = llvm_int 16;
+let i32 = llvm_int 32;
+let i64 = llvm_int 64;
+let i128 = llvm_int 128;
+let i384 = llvm_int 384;
+let i512 = llvm_int 512;
+
+let do_prove = true;
+
+let llvm_verify m func overrides pathsat spec tactic = if do_prove
+  then crucible_llvm_verify m func overrides pathsat spec tactic
+  else crucible_llvm_unsafe_assume_spec m func spec;
+
+let prove_folding_theorem t = prove_print abc (rewrite (cryptol_ss ()) t);

--- a/demos/signal-protocol/saw/signal_protocol.saw
+++ b/demos/signal-protocol/saw/signal_protocol.saw
@@ -1,0 +1,113 @@
+include "buffer_helpers.saw";
+include "load.saw";
+include "saw_helpers.saw";
+
+let buffer_alloc_spec (len : Int) : CrucibleSetup () = do {
+  let lenval = {{ `(len) : [64] }};
+
+  llvm_execute_func [llvm_term lenval];
+
+  buf   <- alloc_buffer_aligned len;
+  llvm_points_to_at_type (llvm_elem buf 0) i64 (llvm_term lenval);
+  llvm_return buf;
+};
+
+let buffer_create_spec (len : Int) = do {
+  let lenval = {{`(len) : [64]}};
+  (data, datap) <- ptr_to_fresh "data" (llvm_array len i8);
+
+  llvm_execute_func [datap, llvm_term lenval];
+
+  buf <- alloc_pointsto_buffer len data;
+  llvm_return buf;
+};
+
+let buffer_copy_spec (len : Int) = do {
+
+  let lenval = {{`(len) : [64]}};
+  data  <- crucible_fresh_var "data" (llvm_array len i8);
+  buffer <- alloc_pointsto_buffer_readonly len data;
+
+  llvm_execute_func[buffer];
+
+  newbuf <- alloc_pointsto_buffer len data;
+  llvm_return newbuf;
+};
+
+//This can be reused for signal_buffer_copy
+let buffer_copy_n_spec (len : Int) (n: Int) = do {
+  let lenval = {{`(len) : [64]}};
+  data  <- crucible_fresh_var "data" (llvm_array len i8);
+  buffer <- alloc_pointsto_buffer_readonly len data;
+
+  llvm_execute_func[buffer, llvm_term {{`(n) : [64]}}];
+
+
+  let newlenval = {{(min `(len) `(n)):[64]}};
+  let newlen = eval_int newlenval;
+
+  newbuf <- alloc_pointsto_buffer newlen {{take`{newlen} data}};
+  llvm_return newbuf;
+  };
+
+let buffer_append_spec (buffer_len : Int) (additional_len : Int) = do {
+  buffer_data <- llvm_fresh_var "buffer_data" (llvm_array buffer_len i8);
+  buffer <- alloc_pointsto_buffer buffer_len buffer_data;
+
+  let additional_len_val = {{`(additional_len) : [64]}};
+  (additional_data, additional_datap) <- ptr_to_fresh "additional_data" (llvm_array additional_len i8);
+
+  llvm_execute_func [buffer, additional_datap, llvm_term additional_len_val];
+
+  let new_len_val = {{ `(buffer_len) + `(additional_len) : [64] }};
+  let new_len = eval_int new_len_val;
+  new_buffer <- alloc_pointsto_buffer new_len {{ buffer_data # additional_data }};
+  llvm_return new_buffer;
+};
+
+let constant_memcmp_spec (n: Int) = do {
+  (s1, s1p) <- ptr_to_fresh "s1" (llvm_array n i8);
+  (s2, s2p) <- ptr_to_fresh "s2" (llvm_array n i8);
+  let nval = {{ `(n) : [64] }};
+
+  llvm_execute_func [s1p, s2p, llvm_term nval];
+
+  let retval = {{ zext`{32} (foldl (||) zero (zipWith (^) s1 s2)) }};
+  llvm_return (llvm_term retval);
+};
+
+let signal_type_init_spec = do {
+  instance <- llvm_alloc (llvm_alias "struct.signal_type_base");
+  let destroy_func = llvm_global "signal_message_destroy";
+
+  llvm_execute_func [instance, destroy_func];
+
+  llvm_points_to (llvm_field instance "ref_count") (llvm_term {{ 1 : [32] }});
+  llvm_points_to (llvm_field instance "destroy") destroy_func;
+};
+
+let signal_type_ref_spec = do {
+  ref_count <- llvm_fresh_var "ref_count" i32;
+  llvm_precond {{ ref_count > 0 }};
+  instance <- llvm_alloc (llvm_alias "struct.signal_type_base");
+  llvm_points_to (llvm_field instance "ref_count") (llvm_term ref_count);
+
+  llvm_execute_func [instance];
+
+  llvm_points_to (llvm_field instance "ref_count") (llvm_term {{ ref_count + 1 }});
+};
+
+let print_tactic = do {
+  //simplify (cryptol_ss ());
+  print_goal;
+  abc;
+};
+
+buffer_alloc_ov     <- llvm_verify m "signal_buffer_alloc"     [] false (buffer_alloc_spec 64) abc;
+buffer_create_ov    <- llvm_verify m "signal_buffer_create"    [] false (buffer_create_spec 64) abc;
+buffer_copy_ov      <- llvm_verify m "signal_buffer_copy"      [] false (buffer_copy_spec 63) abc;
+buffer_copy_n_ov    <- llvm_verify m "signal_buffer_n_copy"    [] false (buffer_copy_n_spec 64 31) abc;
+buffer_append_ov    <- llvm_verify m "signal_buffer_append"    [] false (buffer_append_spec 63 31) abc;
+constant_memcmp_ov  <- llvm_verify m "signal_constant_memcmp"  [] false (constant_memcmp_spec 63) abc;
+signal_type_init_ov <- llvm_verify m "signal_type_init"        [] false signal_type_init_spec abc;
+signal_type_ref_ov  <- llvm_verify m "signal_type_ref"         [] false signal_type_ref_spec abc;


### PR DESCRIPTION
This migrates the code from https://github.com/GaloisInc/signal-verification over to a format suitable for `saw-demos`. This will be the subject of an upcoming blog post; once that is published, a TODO in the `README` for `signal-protocol` can be fixed.