### PR TITLE
Makefile LLVM tooling options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ jobs:
 
     - name: "Install system dependencies"
       shell: bash
-      run: .github/ci.sh install_system_deps
+      run: |
+        .github/ci.sh install_system_deps
+        clang --version
 
     - name: "Install Python"
       uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   CVC4_VERSION: "4.1.8"
   YICES_VERSION: "2.6.2"
   SAW_VERSION: "0.8"
-  LLVM_CONFIG: "llvm-config-12"
+  LLVM_CONFIG: "llvm-config-10"
 
 jobs:
   run-demos:
@@ -30,8 +30,8 @@ jobs:
     - name: "Install system dependencies"
       shell: bash
       run: |
-        sudo apt-get install llvm-12
         .github/ci.sh install_system_deps
+        clang --version
 
     - name: "Install Python"
       uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   Z3_VERSION: "4.8.10"
   CVC4_VERSION: "4.1.8"
   YICES_VERSION: "2.6.2"
-  SAW_VERSION: "0.9"
+  SAW_VERSION: "0.8"
   LLVM_CONFIG: "llvm-config-12"
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   Z3_VERSION: "4.8.10"
   CVC4_VERSION: "4.1.8"
   YICES_VERSION: "2.6.2"
-  SAW_VERSION: "0.8"
+  SAW_VERSION: "0.9"
   LLVM_CONFIG: "llvm-config-12"
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
       shell: bash
       run: |
         .github/ci.sh install_system_deps
-        clang --version
 
     - name: "Install Python"
       uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   CVC4_VERSION: "4.1.8"
   YICES_VERSION: "2.6.2"
   SAW_VERSION: "0.8"
-  LLVM_CONFIG: "llvm-config-9"
+  LLVM_CONFIG: "llvm-config-10"
 
 jobs:
   run-demos:
@@ -30,8 +30,8 @@ jobs:
     - name: "Install system dependencies"
       shell: bash
       run: |
-        sudo apt-get install llvm-9
         .github/ci.sh install_system_deps
+        clang --version
 
     - name: "Install Python"
       uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   CVC4_VERSION: "4.1.8"
   YICES_VERSION: "2.6.2"
   SAW_VERSION: "0.8"
-  LLVM_CONFIG: "llvm-config-10"
+  LLVM_CONFIG: "llvm-config-9"
 
 jobs:
   run-demos:
@@ -30,8 +30,8 @@ jobs:
     - name: "Install system dependencies"
       shell: bash
       run: |
+        sudo apt-get install llvm-9
         .github/ci.sh install_system_deps
-        clang --version
 
     - name: "Install Python"
       uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   CVC4_VERSION: "4.1.8"
   YICES_VERSION: "2.6.2"
   SAW_VERSION: "0.8"
-  LLVM_CONFIG: "llvm-config-10"
+  LLVM_CONFIG: "llvm-config-12"
 
 jobs:
   run-demos:
@@ -30,8 +30,8 @@ jobs:
     - name: "Install system dependencies"
       shell: bash
       run: |
+        sudo apt-get install llvm-12
         .github/ci.sh install_system_deps
-        clang --version
 
     - name: "Install Python"
       uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ env:
   CVC4_VERSION: "4.1.8"
   YICES_VERSION: "2.6.2"
   SAW_VERSION: "0.8"
+  LLVM_CONFIG: "llvm-config-10"
 
 jobs:
   run-demos:

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ even though it may not be the best-performing solver.
 Once SAW is installed, configure your system so that the `saw`
 executable is in your shell's search path.
 
-For C verification, the LLVM toolchain is required. In particular, the
-`clang` compiler is required, and the `llvm-link` utility is necessary
-for any verification involving more than one compilation unit.
+For C verification, the LLVM toolchain is required. In particular, the `clang`
+compiler is required, and the `llvm-link` utility is necessary for any
+verification involving more than one compilation unit. Demos rely on
+`llvm-config --bindir` to locate these tools (customizable via the optional
+`LLVM_CONFIG` environment variable).
 
 For Java verification, JDK 6 through JDK 8 is required. Later versions
 unfortunately do not include a `.jar` file containing the standard

--- a/demos/salsa20/Makefile
+++ b/demos/salsa20/Makefile
@@ -1,6 +1,5 @@
 LLVM_CONFIG ?= llvm-config
-LLVM_BIN_DIR = $(shell $(LLVM_CONFIG) --bindir)
-CLANG=$(LLVM_BIN_DIR)/clang
+CLANG=$(shell $(LLVM_CONFIG) --bindir)/clang
 
 
 all: salsa20.bc salsa20.saw

--- a/demos/salsa20/Makefile
+++ b/demos/salsa20/Makefile
@@ -1,10 +1,15 @@
+LLVM_CONFIG ?= llvm-config
+LLVM_BIN_DIR = $(shell $(LLVM_CONFIG) --bindir)
+CLANG=$(LLVM_BIN_DIR)/clang
+
+
 all: salsa20.bc salsa20.saw
 	saw salsa20.saw
 
 salsa20.c: salsa20.h
 
 %.bc: %.c
-	clang -c -g -emit-llvm $<
+	$(CLANG) -c -g -emit-llvm $<
 
 clean:
 	rm -f salsa20.bc

--- a/demos/signal-protocol/Makefile
+++ b/demos/signal-protocol/Makefile
@@ -1,9 +1,8 @@
 LIBSIGNAL_DIR=libsignal-protocol-c
 LIBSIGNAL_BUILD_DIR=$(LIBSIGNAL_DIR)/build
 LLVM_CONFIG ?= llvm-config
-LLVM_BIN_DIR = $(shell $(LLVM_CONFIG) --bindir)
-CLANG=$(LLVM_BIN_DIR)/clang
-LLVM_LINK=$(LLVM_BIN_DIR)/llvm-link
+CLANG=$(shell $(LLVM_CONFIG) --bindir)/clang
+LLVM_LINK=$(shell $(LLVM_CONFIG) --bindir)/llvm-link
 
 .PHONY: all
 all: all-saw-script
@@ -29,13 +28,13 @@ $(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a:
 
 $(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a.bc: $(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a
 	(cd $(LIBSIGNAL_BUILD_DIR) && \
-	extract-bc -l $(LLVM_LINK_NAME) -b src/libsignal-protocol-c.a)
+	extract-bc -l $(LLVM_LINK) -b src/libsignal-protocol-c.a)
 
 c/libsignal-everything.bc: $(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a.bc c/dummy_signal_crypto_provider.bc
-	$(LLVM_LINK_NAME) $^ -o $@
+	$(LLVM_LINK) $^ -o $@
 
 c/dummy_signal_crypto_provider.bc: c/dummy_signal_crypto_provider.c
-	$(CLANG_NAME) -g -c -emit-llvm $< -o $@ -I$(LIBSIGNAL_DIR)/src
+	$(CLANG) -g -c -emit-llvm $< -o $@ -I$(LIBSIGNAL_DIR)/src
 
 .PHONY: clean
 clean:

--- a/demos/signal-protocol/Makefile
+++ b/demos/signal-protocol/Makefile
@@ -2,7 +2,8 @@ LIBSIGNAL_DIR=libsignal-protocol-c
 LIBSIGNAL_BUILD_DIR=$(LIBSIGNAL_DIR)/build
 LLVM_CONFIG ?= llvm-config
 CLANG=$(shell $(LLVM_CONFIG) --bindir)/clang
-LLVM_LINK=$(shell $(LLVM_CONFIG) --bindir)/llvm-link
+# N.B., wllvm requires the `LLVM_LINK_NAME` environment variable to function properly
+LLVM_LINK_NAME=$(shell $(LLVM_CONFIG) --bindir)/llvm-link
 
 .PHONY: all
 all: all-saw-script
@@ -28,10 +29,10 @@ $(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a:
 
 $(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a.bc: $(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a
 	(cd $(LIBSIGNAL_BUILD_DIR) && \
-	extract-bc -l $(LLVM_LINK) -b src/libsignal-protocol-c.a)
+	extract-bc -l $(LLVM_LINK_NAME) -b src/libsignal-protocol-c.a)
 
 c/libsignal-everything.bc: $(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a.bc c/dummy_signal_crypto_provider.bc
-	$(LLVM_LINK) $^ -o $@
+	$(LLVM_LINK_NAME) $^ -o $@
 
 c/dummy_signal_crypto_provider.bc: c/dummy_signal_crypto_provider.c
 	$(CLANG) -g -c -emit-llvm $< -o $@ -I$(LIBSIGNAL_DIR)/src

--- a/demos/signal-protocol/Makefile
+++ b/demos/signal-protocol/Makefile
@@ -2,8 +2,8 @@ LIBSIGNAL_DIR=libsignal-protocol-c
 LIBSIGNAL_BUILD_DIR=$(LIBSIGNAL_DIR)/build
 LLVM_CONFIG ?= llvm-config
 LLVM_BIN_DIR = $(shell $(LLVM_CONFIG) --bindir)
-CLANG_NAME=$(LLVM_BIN_DIR)/clang
-LLVM_LINK_NAME=$(LLVM_BIN_DIR)/llvm-link
+CLANG=$(LLVM_BIN_DIR)/clang
+LLVM_LINK=$(LLVM_BIN_DIR)/llvm-link
 
 .PHONY: all
 all: all-saw-script

--- a/demos/signal-protocol/Makefile
+++ b/demos/signal-protocol/Makefile
@@ -1,9 +1,8 @@
 LIBSIGNAL_DIR=libsignal-protocol-c
 LIBSIGNAL_BUILD_DIR=$(LIBSIGNAL_DIR)/build
-LLVM_CONFIG ?= llvm-config
-LLVM_BIN_DIR = $(shell $(LLVM_CONFIG) --bindir)
-CLANG_NAME=$(LLVM_BIN_DIR)/clang
-LLVM_LINK_NAME=$(LLVM_BIN_DIR)/llvm-link
+CLANG ?= clang
+# N.B., the Makefile expects `llvm-link` to be colocated with `clang` for the next line to work:
+LLVM_LINK_NAME=$(shell dirname $(shell realpath $(shell which $(CLANG))))/llvm-link
 
 .PHONY: all
 all: all-saw-script
@@ -35,7 +34,7 @@ c/libsignal-everything.bc: $(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a.bc 
 	$(LLVM_LINK_NAME) $^ -o $@
 
 c/dummy_signal_crypto_provider.bc: c/dummy_signal_crypto_provider.c
-	$(CLANG_NAME) -g -c -emit-llvm $< -o $@ -I$(LIBSIGNAL_DIR)/src
+	$(CLANG) -g -c -emit-llvm $< -o $@ -I$(LIBSIGNAL_DIR)/src
 
 .PHONY: clean
 clean:

--- a/demos/signal-protocol/Makefile
+++ b/demos/signal-protocol/Makefile
@@ -1,9 +1,10 @@
 LIBSIGNAL_DIR=libsignal-protocol-c
 LIBSIGNAL_BUILD_DIR=$(LIBSIGNAL_DIR)/build
 LLVM_CONFIG ?= llvm-config
-CLANG=$(shell $(LLVM_CONFIG) --bindir)/clang
+LLVM_HOME=$(shell $(LLVM_CONFIG) --bindir)
+CLANG=$(LLVM_HOME)/clang
 # N.B., wllvm requires the `LLVM_LINK_NAME` environment variable to function properly
-LLVM_LINK_NAME=$(shell $(LLVM_CONFIG) --bindir)/llvm-link
+LLVM_LINK_NAME=$(LLVM_HOME)/llvm-link
 
 .PHONY: all
 all: all-saw-script
@@ -24,8 +25,8 @@ libsignal: c/libsignal-everything.bc
 $(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a:
 	mkdir -p $(LIBSIGNAL_BUILD_DIR)
 	(cd $(LIBSIGNAL_BUILD_DIR) && \
-	LLVM_COMPILER=clang cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=wllvm .. && \
-	LLVM_COMPILER=clang make)
+	PATH="$(LLVM_HOME):$(PATH)" LLVM_COMPILER=clang cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=wllvm .. && \
+	PATH="$(LLVM_HOME):$(PATH)" LLVM_COMPILER=clang make)
 
 $(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a.bc: $(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a
 	(cd $(LIBSIGNAL_BUILD_DIR) && \

--- a/demos/signal-protocol/Makefile
+++ b/demos/signal-protocol/Makefile
@@ -1,8 +1,9 @@
 LIBSIGNAL_DIR=libsignal-protocol-c
 LIBSIGNAL_BUILD_DIR=$(LIBSIGNAL_DIR)/build
-CLANG ?= clang
-# N.B., the Makefile expects `llvm-link` to be colocated with `clang` for the next line to work:
-LLVM_LINK_NAME=$(shell dirname $(shell realpath $(shell which $(CLANG))))/llvm-link
+LLVM_CONFIG ?= llvm-config
+LLVM_BIN_DIR = $(shell $(LLVM_CONFIG) --bindir)
+CLANG_NAME=$(LLVM_BIN_DIR)/clang
+LLVM_LINK_NAME=$(LLVM_BIN_DIR)/llvm-link
 
 .PHONY: all
 all: all-saw-script
@@ -34,7 +35,7 @@ c/libsignal-everything.bc: $(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a.bc 
 	$(LLVM_LINK_NAME) $^ -o $@
 
 c/dummy_signal_crypto_provider.bc: c/dummy_signal_crypto_provider.c
-	$(CLANG) -g -c -emit-llvm $< -o $@ -I$(LIBSIGNAL_DIR)/src
+	$(CLANG_NAME) -g -c -emit-llvm $< -o $@ -I$(LIBSIGNAL_DIR)/src
 
 .PHONY: clean
 clean:

--- a/demos/signal-protocol/Makefile
+++ b/demos/signal-protocol/Makefile
@@ -1,6 +1,9 @@
 LIBSIGNAL_DIR=libsignal-protocol-c
 LIBSIGNAL_BUILD_DIR=$(LIBSIGNAL_DIR)/build
-LLVM_LINK_NAME=$(shell dirname $(shell readlink -f $(shell which clang)))/llvm-link
+LLVM_CONFIG ?= llvm-config
+LLVM_BIN_DIR = $(shell $(LLVM_CONFIG) --bindir)
+CLANG_NAME=$(LLVM_BIN_DIR)/clang
+LLVM_LINK_NAME=$(LLVM_BIN_DIR)/llvm-link
 
 .PHONY: all
 all: all-saw-script
@@ -17,6 +20,7 @@ all-python: libsignal
 
 libsignal: c/libsignal-everything.bc
 
+# N.B., the `LLVM_COMPILER` variable needs to be literally `clang`, not a PATH to clang
 $(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a:
 	mkdir -p $(LIBSIGNAL_BUILD_DIR)
 	(cd $(LIBSIGNAL_BUILD_DIR) && \
@@ -31,7 +35,7 @@ c/libsignal-everything.bc: $(LIBSIGNAL_BUILD_DIR)/src/libsignal-protocol-c.a.bc 
 	$(LLVM_LINK_NAME) $^ -o $@
 
 c/dummy_signal_crypto_provider.bc: c/dummy_signal_crypto_provider.c
-	clang -g -c -emit-llvm $< -o $@ -I$(LIBSIGNAL_DIR)/src
+	$(CLANG_NAME) -g -c -emit-llvm $< -o $@ -I$(LIBSIGNAL_DIR)/src
 
 .PHONY: clean
 clean:

--- a/demos/xxhash/Makefile
+++ b/demos/xxhash/Makefile
@@ -1,3 +1,8 @@
+LLVM_CONFIG ?= llvm-config
+LLVM_BIN_DIR = $(shell $(LLVM_CONFIG) --bindir)
+CLANG=$(LLVM_BIN_DIR)/clang
+
+
 all: prove
 
 prove: xxhash32-ref.bc xxhash64-ref.bc
@@ -5,7 +10,7 @@ prove: xxhash32-ref.bc xxhash64-ref.bc
 	saw xxhash64-ref.saw
 
 %ref.bc: %ref.c
-	clang $< -o $@ -c -emit-llvm -O0 -std=c90
+	$(CLANG) $< -o $@ -c -emit-llvm -O0 -std=c90
 
 clean:
 	$(RM) xxhash32-ref.bc xxhash64-ref.bc

--- a/demos/xxhash/Makefile
+++ b/demos/xxhash/Makefile
@@ -1,6 +1,5 @@
 LLVM_CONFIG ?= llvm-config
-LLVM_BIN_DIR = $(shell $(LLVM_CONFIG) --bindir)
-CLANG=$(LLVM_BIN_DIR)/clang
+CLANG=$(shell $(LLVM_CONFIG) --bindir)/clang
 
 
 all: prove

--- a/templates/c/Makefile
+++ b/templates/c/Makefile
@@ -1,8 +1,11 @@
+LLVM_CONFIG ?= llvm-config
+CLANG=$(shell $(LLVM_CONFIG) --bindir)/clang
+
 all: dotprod.bc dotprod.saw
 	saw dotprod.saw
 
 %.bc: %.c
-	clang -c -g -emit-llvm $<
+	$(CLANG) -c -g -emit-llvm $<
 
 clean:
 	rm -f dotprod.bc


### PR DESCRIPTION
The `-f` flag for `readlink` is not supported on MacOS, which means this Makefile as is was a little troublesome due to this line:
```
LLVM_LINK_NAME=$(shell dirname $(shell readlink -f $(shell which clang)))/llvm-link
```

I've tweaked things to instead be based off of the `LLVM_CONFIG` environment variable (default to just `llvm-config` if not set) and then use the `--bindir` flag to find the appropriate `clang` and `llvm-link` executables.

Happy to try a different solution if there's something undesirable about this approach.